### PR TITLE
테이블에 대한 영속성 객체 추가 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JWT Jackson 모듈
 
 	// DB
-	implementation 'org.postgresql:postgresql:42.7.3' // PostgreSQL JDBC Driver
+	implementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1' // MariaDB JDBC Driver
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // Spring Data JPA
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // Hibernate Validator
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final' // Bean Validation

--- a/src/main/java/com/stempo/api/domain/domain/model/BoardCategory.java
+++ b/src/main/java/com/stempo/api/domain/domain/model/BoardCategory.java
@@ -1,0 +1,15 @@
+package com.stempo.api.domain.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BoardCategory {
+
+    NOTICE("공지사항"),
+    FAQ("자주 묻는 질문"),
+    SUGGESTION("건의하기");
+
+    private final String description;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/AchievementEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/AchievementEntity.java
@@ -1,0 +1,39 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "achievement")
+public class AchievementEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 100, message = "Name must be between 1 and 100 characters")
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/ArticleEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/ArticleEntity.java
@@ -1,0 +1,43 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "article")
+public class ArticleEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 100, message = "Title must be between 1 and 100 characters")
+    private String title;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 10000, message = "Content must be between 1 and 10000 characters")
+    private String content;
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    @URL(message = "Invalid URL")
+    private String articleUrl;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/BaseEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/BaseEntity.java
@@ -1,0 +1,41 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/stempo/api/domain/persistence/entity/BoardEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/BoardEntity.java
@@ -1,0 +1,47 @@
+package com.stempo.api.domain.persistence.entity;
+
+import com.stempo.api.domain.domain.model.BoardCategory;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "board")
+public class BoardEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BoardCategory category;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 100, message = "Title must be between 1 and 100 characters")
+    private String title;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 10000, message = "Content must be between 1 and 10000 characters")
+    private String content;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/FileEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/FileEntity.java
@@ -1,0 +1,34 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "file")
+public class FileEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String fileUrl;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/RecordEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/RecordEntity.java
@@ -1,0 +1,40 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "record")
+public class RecordEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private Double accuracy;
+
+    @Column(nullable = false)
+    private Integer duration;
+
+    @Column(nullable = false)
+    private Integer steps;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/UserEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/UserEntity.java
@@ -1,0 +1,28 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "user")
+public class UserEntity extends BaseEntity {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private String password;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/VideoEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/VideoEntity.java
@@ -1,0 +1,43 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "video")
+public class VideoEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 100, message = "Title must be between 1 and 100 characters")
+    private String title;
+
+    @Column(nullable = false)
+    @Size(min = 1, max = 10000, message = "Content must be between 1 and 10000 characters")
+    private String content;
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    @URL(message = "Invalid URL")
+    private String videoUrl;
+}

--- a/src/main/java/com/stempo/api/global/config/JpaConfig.java
+++ b/src/main/java/com/stempo/api/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.stempo.api.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
## Summary

> #7

이번 PR에서는 Stempo 애플리케이션의 1차 MVP 개발을 위한 데이터베이스 스키마 설정을 포함하고 있습니다.
이 스키마는 기록, 업적, 영상 정보, 아티클 정보, 게시판, 파일 관리, 사용자 정보 등의 기능을 지원합니다.

## Tasks

- **기록 테이블 생성**
    - 훈련 정확도, 시행일시, 지속 시간, 걸음 수를 기록하는 테이블을 추가했습니다.
    - 필드: `id`, `user_id`, `accuracy`, `duration`, `steps`, `created_at`, `updated_at`, `deleted`

- **업적 테이블 생성**
    - 업적 이름과 설명, 사진 URL을 기록하는 테이블을 추가했습니다.
    - 필드: `id`, `name`, `description`, `image_url`, `created_at`, `updated_at`, `deleted`

- **영상 정보 테이블 생성**
    - 재활운동 영상의 제목, 내용, 썸네일 URL, 비디오 URL 정보를 저장하는 테이블을 추가했습니다.
    - 필드: `id`, `title`, `content`, `thumbnail_url`, `video_url`, `created_at`, `updated_at`, `deleted`

- **아티클 정보 테이블 생성**
    - 재활 관련 정보의 제목, 내용, 썸네일 URL, 아티클 URL 정보를 저장하는 테이블을 추가했습니다.
    - 필드: `id`, `title`, `content`, `thumbnail_url`, `article_url`, `created_at`, `updated_at`, `deleted`

- **게시판 테이블 생성**
    - 공지사항, FAQ, 건의하기 등의 게시판 기능을 지원하는 테이블을 추가했습니다.
    - 필드: `id`, `user_id`, `category`, `title`, `content`, `created_at`, `updated_at`, `deleted`

- **파일 관리 테이블 생성**
    - 사용자와 관련된 파일을 관리하기 위한 테이블을 추가했습니다.
    - 필드: `id`, `file_name`, `file_url`, `created_at`, `updated_at`, `deleted`

- **사용자 테이블 생성**
    - 사용자 정보를 저장하는 테이블을 추가했습니다.
    - 필드: `id`, `password`, `created_at`, `updated_at`, `deleted`

## Screenshot
![image](https://github.com/user-attachments/assets/40e7d703-738b-413f-802b-1e4293dabcbb)
