### PR TITLE
시행한 훈련의 정확도, 시행일시 기록 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/service/RecordService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/RecordService.java
@@ -1,0 +1,14 @@
+package com.stempo.api.domain.application.service;
+
+import com.stempo.api.domain.presentation.dto.request.RecordRequestDto;
+import com.stempo.api.domain.presentation.dto.response.RecordResponseDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RecordService {
+
+    String record(RecordRequestDto requestDto);
+
+    List<RecordResponseDto> getRecordsByDateRange(LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/stempo/api/domain/application/service/RecordServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/RecordServiceImpl.java
@@ -1,0 +1,37 @@
+package com.stempo.api.domain.application.service;
+
+import com.stempo.api.domain.domain.model.Record;
+import com.stempo.api.domain.domain.repository.RecordRepository;
+import com.stempo.api.domain.presentation.dto.request.RecordRequestDto;
+import com.stempo.api.domain.presentation.dto.response.RecordResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecordServiceImpl implements RecordService {
+
+    private final UserService userService;
+    private final RecordRepository recordRepository;
+
+    @Override
+    public String record(RecordRequestDto requestDto) {
+        String deviceTag = userService.getCurrentDeviceTag();
+        Record record = RecordRequestDto.toDomain(requestDto, deviceTag);
+        return recordRepository.save(record).getDeviceTag();
+    }
+
+    @Override
+    public List<RecordResponseDto> getRecordsByDateRange(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atStartOfDay().plusDays(1);
+        List<Record> records = recordRepository.findByDateBetween(startDateTime, endDateTime);
+        return records.stream()
+                .map(RecordResponseDto::toDto)
+                .toList();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/service/UserService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserService.java
@@ -11,4 +11,6 @@ public interface UserService {
     Optional<User> findById(String id);
 
     boolean existsById(String id);
+
+    String getCurrentDeviceTag();
 }

--- a/src/main/java/com/stempo/api/domain/application/service/UserServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.stempo.api.domain.application.service;
 
 import com.stempo.api.domain.domain.model.User;
 import com.stempo.api.domain.domain.repository.UserRepository;
+import com.stempo.api.global.auth.util.AuthUtil;
 import com.stempo.api.global.util.PasswordUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,5 +34,10 @@ public class UserServiceImpl implements UserService {
     @Override
     public boolean existsById(String id) {
         return userRepository.existsById(id);
+    }
+
+    @Override
+    public String getCurrentDeviceTag() {
+        return AuthUtil.getAuthenticationInfoDeviceTag();
     }
 }

--- a/src/main/java/com/stempo/api/domain/domain/model/Record.java
+++ b/src/main/java/com/stempo/api/domain/domain/model/Record.java
@@ -1,0 +1,25 @@
+package com.stempo.api.domain.domain.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Record {
+
+    private Long id;
+    private String deviceTag;
+    private Double accuracy;
+    private Integer duration;
+    private Integer steps;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
@@ -1,0 +1,13 @@
+package com.stempo.api.domain.domain.repository;
+
+import com.stempo.api.domain.domain.model.Record;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface RecordRepository {
+
+    Record save(Record record);
+
+    List<Record> findByDateBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/RecordEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/RecordEntity.java
@@ -27,14 +27,11 @@ public class RecordEntity extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String userId;
+    private String deviceTag;
 
     @Column(nullable = false)
     private Double accuracy;
 
-    @Column(nullable = false)
     private Integer duration;
-
-    @Column(nullable = false)
     private Integer steps;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/mappper/RecordMapper.java
+++ b/src/main/java/com/stempo/api/domain/persistence/mappper/RecordMapper.java
@@ -1,0 +1,30 @@
+package com.stempo.api.domain.persistence.mappper;
+
+import com.stempo.api.domain.domain.model.Record;
+import com.stempo.api.domain.persistence.entity.RecordEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecordMapper {
+
+    public RecordEntity toEntity(Record record) {
+        return RecordEntity.builder()
+                .id(record.getId())
+                .deviceTag(record.getDeviceTag())
+                .accuracy(record.getAccuracy())
+                .duration(record.getDuration())
+                .steps(record.getSteps())
+                .build();
+    }
+
+    public Record toDomain(RecordEntity recordEntity) {
+        return Record.builder()
+                .id(recordEntity.getId())
+                .deviceTag(recordEntity.getDeviceTag())
+                .accuracy(recordEntity.getAccuracy())
+                .duration(recordEntity.getDuration())
+                .steps(recordEntity.getSteps())
+                .createdAt(recordEntity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordJpaRepository.java
@@ -1,0 +1,21 @@
+package com.stempo.api.domain.persistence.repository;
+
+import com.stempo.api.domain.persistence.entity.RecordEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface RecordJpaRepository extends JpaRepository<RecordEntity, Long> {
+
+    @Query("SELECT r " +
+            "FROM RecordEntity r " +
+            "WHERE r.createdAt BETWEEN :startDateTime AND :endDateTime " +
+            "ORDER BY r.createdAt ASC")
+    List<RecordEntity> findByDateBetween(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.stempo.api.domain.persistence.repository;
+
+import com.stempo.api.domain.domain.model.Record;
+import com.stempo.api.domain.domain.repository.RecordRepository;
+import com.stempo.api.domain.persistence.entity.RecordEntity;
+import com.stempo.api.domain.persistence.mappper.RecordMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RecordRepositoryImpl implements RecordRepository {
+
+    private final RecordJpaRepository repository;
+    private final RecordMapper mapper;
+
+    @Override
+    public Record save(Record record) {
+        RecordEntity jpaEntity = mapper.toEntity(record);
+        RecordEntity savedEntity = repository.save(jpaEntity);
+        return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<Record> findByDateBetween(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        List<RecordEntity> jpaEntities = repository.findByDateBetween(startDateTime, endDateTime);
+        return jpaEntities.stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
@@ -14,18 +14,18 @@ import java.util.Optional;
 public class UploadedFileRepositoryImpl implements UploadedFileRepository {
 
     private final UploadedFileJpaRepository repository;
-    private final UploadedFileMapper uploadedFileMapper;
+    private final UploadedFileMapper mapper;
 
     @Override
     public UploadedFile save(UploadedFile uploadedFile) {
-        UploadedFileEntity jpaEntity = uploadedFileMapper.toEntity(uploadedFile);
+        UploadedFileEntity jpaEntity = mapper.toEntity(uploadedFile);
         UploadedFileEntity savedEntity = repository.save(jpaEntity);
-        return uploadedFileMapper.toDomain(savedEntity);
+        return mapper.toDomain(savedEntity);
     }
 
     @Override
     public Optional<UploadedFile> findByOriginalFileName(String fileName) {
         return repository.findByOriginalFileName(fileName)
-                .map(uploadedFileMapper::toDomain);
+                .map(mapper::toDomain);
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UserRepositoryImpl.java
@@ -14,19 +14,19 @@ import java.util.Optional;
 public class UserRepositoryImpl implements UserRepository {
 
     private final UserJpaRepository repository;
-    private final UserMapper userMapper;
+    private final UserMapper mapper;
 
     @Override
     public User save(User user) {
-        UserEntity jpaEntity = userMapper.toEntity(user);
+        UserEntity jpaEntity = mapper.toEntity(user);
         UserEntity savedEntity = repository.save(jpaEntity);
-        return userMapper.toDomain(savedEntity);
+        return mapper.toDomain(savedEntity);
     }
 
     @Override
     public Optional<User> findById(String id) {
         return repository.findById(id)
-                .map(userMapper::toDomain);
+                .map(mapper::toDomain);
     }
 
     @Override

--- a/src/main/java/com/stempo/api/domain/presentation/LoginController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/LoginController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +35,7 @@ public class LoginController {
     }
 
     @Operation(summary = "[U] 토큰 재발급", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/vi/reissue")
     public ApiResponse<TokenInfo> reissueToken(
             HttpServletRequest request,

--- a/src/main/java/com/stempo/api/domain/presentation/RecordController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RecordController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +26,7 @@ public class RecordController {
     private final RecordService recordService;
 
     @Operation(summary = "[U] 재활 운동 기록", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/records")
     public ApiResponse<String> record(
             @Valid @RequestBody RecordRequestDto requestDto
@@ -34,6 +36,7 @@ public class RecordController {
     }
 
     @Operation(summary = "[U] 내 재활 운동 기록 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @GetMapping("/api/v1/records")
     public ApiResponse<List<RecordResponseDto>> getRecords(
             @RequestParam(name = "startDate") LocalDate startDate,

--- a/src/main/java/com/stempo/api/domain/presentation/RecordController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RecordController.java
@@ -1,0 +1,45 @@
+package com.stempo.api.domain.presentation;
+
+import com.stempo.api.domain.application.service.RecordService;
+import com.stempo.api.domain.presentation.dto.request.RecordRequestDto;
+import com.stempo.api.domain.presentation.dto.response.RecordResponseDto;
+import com.stempo.api.global.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Record", description = "기록")
+public class RecordController {
+
+    private final RecordService recordService;
+
+    @Operation(summary = "[U] 재활 운동 기록", description = "ROLE_USER 이상의 권한이 필요함")
+    @PostMapping("/api/v1/records")
+    public ApiResponse<String> record(
+            @Valid @RequestBody RecordRequestDto requestDto
+    ) {
+        String deviceTag = recordService.record(requestDto);
+        return ApiResponse.success(deviceTag);
+    }
+
+    @Operation(summary = "[U] 내 재활 운동 기록 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @GetMapping("/api/v1/records")
+    public ApiResponse<List<RecordResponseDto>> getRecords(
+            @RequestParam(name = "startDate") LocalDate startDate,
+            @RequestParam(name = "endDate") LocalDate endDate
+    ) {
+        List<RecordResponseDto> records = recordService.getRecordsByDateRange(startDate, endDate);
+        return ApiResponse.success(records);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/presentation/RhythmController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RhythmController.java
@@ -5,6 +5,7 @@ import com.stempo.api.global.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +18,7 @@ public class RhythmController {
     private final RhythmService rhythmService;
 
     @Operation(summary = "[U] 리듬 생성", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/rhythm/{bpm}")
     public ApiResponse<String> generateRhythm(
             @PathVariable(name = "bpm") int bpm

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/RecordRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/RecordRequestDto.java
@@ -1,0 +1,36 @@
+package com.stempo.api.domain.presentation.dto.request;
+
+import com.stempo.api.domain.domain.model.Record;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RecordRequestDto {
+
+    @NotNull(message = "Accuracy is required")
+    @PositiveOrZero(message = "Accuracy must be a positive value or zero")
+    @Schema(description = "정확도", example = "0.0")
+    private Double accuracy;
+
+    @PositiveOrZero(message = "Duration must be a positive value or zero")
+    @Schema(description = "재활 운동 시간(초)", example = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer duration;
+
+    @PositiveOrZero(message = "Steps must be a positive value or zero")
+    @Schema(description = "걸음 수", example = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer steps;
+
+
+    public static Record toDomain(RecordRequestDto requestDto, String deviceTag) {
+        return Record.builder()
+                .deviceTag(deviceTag)
+                .accuracy(requestDto.getAccuracy())
+                .duration(requestDto.getDuration())
+                .steps(requestDto.getSteps())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordResponseDto.java
@@ -1,0 +1,26 @@
+package com.stempo.api.domain.presentation.dto.response;
+
+import com.stempo.api.domain.domain.model.Record;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class RecordResponseDto {
+
+    private Double accuracy;
+    private Integer duration;
+    private Integer steps;
+    private LocalDate date;
+
+    public static RecordResponseDto toDto(Record record) {
+        return RecordResponseDto.builder()
+                .accuracy(record.getAccuracy())
+                .duration(record.getDuration())
+                .steps(record.getSteps())
+                .date(record.getCreatedAt().toLocalDate())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/global/auth/exception/AuthenticationInfoNotFoundException.java
+++ b/src/main/java/com/stempo/api/global/auth/exception/AuthenticationInfoNotFoundException.java
@@ -1,0 +1,14 @@
+package com.stempo.api.global.auth.exception;
+
+public class AuthenticationInfoNotFoundException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "인증 정보가 존재하지 않습니다.";
+
+    public AuthenticationInfoNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public AuthenticationInfoNotFoundException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/stempo/api/global/auth/util/AuthUtil.java
+++ b/src/main/java/com/stempo/api/global/auth/util/AuthUtil.java
@@ -1,0 +1,25 @@
+package com.stempo.api.global.auth.util;
+
+import com.stempo.api.global.auth.exception.AuthenticationInfoNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+public class AuthUtil {
+
+    public static User getAuthenticationInfo() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new AuthenticationInfoNotFoundException();
+        }
+        if (authentication.getPrincipal() instanceof User) {
+            return (User) authentication.getPrincipal();
+        } else {
+            throw new AuthenticationInfoNotFoundException("인증 정보가 존재하지 않습니다.");
+        }
+    }
+
+    public static String getAuthenticationInfoDeviceTag() {
+        return getAuthenticationInfo().getUsername();
+    }
+}

--- a/src/main/java/com/stempo/api/global/common/dto/ErrorResponse.java
+++ b/src/main/java/com/stempo/api/global/common/dto/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.stempo.api.global.common.dto;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse<T> {
+
+    @Builder.Default
+    private Boolean success = false;
+    private T data;
+    private String errorMessage;
+
+    public static <T> ErrorResponse<T> failure(Exception e) {
+        String exceptionName = e.getClass().getSimpleName();
+        return ErrorResponse.<T> builder()
+                .errorMessage(exceptionName)
+                .build();
+    }
+
+    public String toJson() {
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        return gson.toJson(this);
+    }
+}

--- a/src/main/java/com/stempo/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/stempo/api/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.stempo.api.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableGlobalMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
     private final RedisTokenService redisTokenService;

--- a/src/main/java/com/stempo/api/global/config/WebConfig.java
+++ b/src/main/java/com/stempo/api/global/config/WebConfig.java
@@ -1,11 +1,13 @@
 package com.stempo.api.global.config;
 
+import com.stempo.api.global.handler.ApiLoggingInterceptor;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.resource.PathResourceResolver;
@@ -17,6 +19,8 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Slf4j
 public class WebConfig implements WebMvcConfigurer {
+
+    private final ApiLoggingInterceptor apiLoggingInterceptor;
 
     @Value("${resource.file.path}")
     private String filePath;
@@ -41,5 +45,10 @@ public class WebConfig implements WebMvcConfigurer {
                         throw new FileNotFoundException("Resource not found: " + resourcePath);
                     }
                 });
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(apiLoggingInterceptor);
     }
 }

--- a/src/main/java/com/stempo/api/global/handler/ApiLoggingInterceptor.java
+++ b/src/main/java/com/stempo/api/global/handler/ApiLoggingInterceptor.java
@@ -1,0 +1,42 @@
+package com.stempo.api.global.handler;
+
+import com.stempo.api.global.util.HttpReqResUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@Slf4j
+public class ApiLoggingInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws Exception {
+        request.setAttribute("startTime", System.currentTimeMillis());
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, @NotNull Object handler, Exception ex) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
+        String clientIpAddress = HttpReqResUtil.getClientIpAddressIfServletRequestExist();
+        String requestUrl = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        int httpStatus = response.getStatus();
+
+        long startTime = (Long) request.getAttribute("startTime");
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        if (ex == null) {
+            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, requestUrl, httpMethod, httpStatus, duration);
+        } else {
+            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, requestUrl, httpMethod, httpStatus, duration, ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/stempo/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stempo/api/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,111 @@
+package com.stempo.api.global.handler;
+
+import com.google.gson.stream.MalformedJsonException;
+import com.stempo.api.domain.application.exception.DirectoryCreationException;
+import com.stempo.api.domain.application.exception.FileUploadFailException;
+import com.stempo.api.domain.application.exception.RhythmGenerationException;
+import com.stempo.api.global.auth.exception.AuthenticationInfoNotFoundException;
+import com.stempo.api.global.auth.exception.TokenForgeryException;
+import com.stempo.api.global.auth.exception.TokenNotFoundException;
+import com.stempo.api.global.auth.exception.TokenValidateException;
+import com.stempo.api.global.common.dto.ApiResponse;
+import com.stempo.api.global.common.dto.ErrorResponse;
+import com.stempo.api.global.exception.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.sqm.UnknownPathException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionException;
+
+@RestControllerAdvice(basePackages = "com.stempo.api")
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+            StringIndexOutOfBoundsException.class,
+            MissingServletRequestParameterException.class,
+            MalformedJsonException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            IllegalAccessException.class,
+            NumberFormatException.class,
+            UnknownPathException.class
+    })
+    public ErrorResponse<Exception> badRequestException(HttpServletResponse response, Exception e) {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return ErrorResponse.failure(e);
+    }
+
+    @ExceptionHandler({
+            AuthenticationInfoNotFoundException.class,
+            AccessDeniedException.class,
+            BadCredentialsException.class,
+            TokenValidateException.class,
+            TokenNotFoundException.class,
+            TokenForgeryException.class,
+    })
+    public ApiResponse<Void> unAuthorizeException(HttpServletResponse response, Exception e) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return ApiResponse.failure();
+    }
+
+    @ExceptionHandler({
+            NullPointerException.class,
+            NotFoundException.class,
+            NoSuchElementException.class,
+            FileNotFoundException.class,
+    })
+    public ErrorResponse<Exception> notFoundException(HttpServletResponse response, Exception e) {
+        response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        return ErrorResponse.failure(e);
+    }
+
+    @ExceptionHandler({
+            IllegalStateException.class,
+            FileUploadFailException.class,
+            DataIntegrityViolationException.class,
+            IncorrectResultSizeDataAccessException.class,
+            ArrayIndexOutOfBoundsException.class,
+            IOException.class,
+            TransactionSystemException.class,
+            SecurityException.class,
+            CompletionException.class,
+            InvalidDataAccessApiUsageException.class,
+            DirectoryCreationException.class,
+            RhythmGenerationException.class,
+            Exception.class
+    })
+    public ApiResponse<Void> serverException(HttpServletRequest request, HttpServletResponse response, Exception e) {
+        log.warn(e.getMessage());
+        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        return ApiResponse.failure();
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            ConstraintViolationException.class
+    })
+    public ApiResponse<Void> handleValidationException(HttpServletResponse response, Exception e) {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return ApiResponse.failure();
+    }
+}

--- a/src/main/java/com/stempo/api/global/util/HttpReqResUtil.java
+++ b/src/main/java/com/stempo/api/global/util/HttpReqResUtil.java
@@ -1,0 +1,36 @@
+package com.stempo.api.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class HttpReqResUtil {
+
+    private static final String[] IP_HEADER_CANDIDATES = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_X_FORWARDED_FOR",
+            "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_FORWARDED_FOR",
+            "HTTP_FORWARDED",
+            "HTTP_VIA",
+            "REMOTE_ADDR"
+    };
+
+    public static String getClientIpAddressIfServletRequestExist() {
+        if (RequestContextHolder.getRequestAttributes() == null) {
+            return "0.0.0.0";
+        }
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        for (String header : IP_HEADER_CANDIDATES) {
+            String ipList = request.getHeader(header);
+            if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
+                return ipList.split(",")[0];
+            }
+        }
+        return request.getRemoteAddr();
+    }
+}


### PR DESCRIPTION
## Summary

> #13 

이 PR은 사용자가 수행한 재활 운동의 정확도와 시행일시를 기록하는 기능을 추가합니다.
사용자는 재활 운동의 진행 상황을 체계적으로 기록하고 조회할 수 있습니다.

## Tasks

- 재활 운동 기록 저장
    - 정확도, 운동 시간, 걸음 수를 포함한 재활 운동 기록을 저장하는 기능 구현
    - 양수 또는 0만 입력되도록 유효성 검증 추가 (@PositiveOrZero 어노테이션 사용)

- 재활 운동 기록 조회
    - 사용자의 재활 운동 기록을 조회하는 기능 구현
    - 기록의 생성일시를 기준으로 조회 가능하도록 수정

- API 엔드포인트 추가
    - /api/v1/records POST 엔드포인트: 재활 운동 기록 저장
    - /api/v1/records GET 엔드포인트: 재활 운동 기록 조회

- GlobalExceptionHandler 추가
    - 애플리케이션 전역에서 발생하는 예외를 처리하는 글로벌 예외 처리기 구현
    - 일관된 에러 응답 형식을 제공하여 클라이언트가 예외 상황을 명확히 이해할 수 있도록 개선

- API 로깅 추가
    - API 요청 및 응답 로깅 기능 추가
    - API 호출 시마다 로그를 기록하여 추적 및 디버깅 용이성 향상