### PR TITLE
업적 기록 및 조회 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/event/AchievementDeletedEvent.java
+++ b/src/main/java/com/stempo/api/domain/application/event/AchievementDeletedEvent.java
@@ -1,0 +1,15 @@
+package com.stempo.api.domain.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class AchievementDeletedEvent extends ApplicationEvent {
+
+    private final Long achievementId;
+
+    public AchievementDeletedEvent(Object source, Long achievementId) {
+        super(source);
+        this.achievementId = achievementId;
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/AchievementEventDispatcher.java
+++ b/src/main/java/com/stempo/api/domain/application/event/AchievementEventDispatcher.java
@@ -1,0 +1,24 @@
+package com.stempo.api.domain.application.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AchievementEventDispatcher {
+
+    private final List<AchievementEventProcessor> processors;
+
+    @EventListener
+    public void handleAchievementDeletedEvent(AchievementDeletedEvent event) {
+        processors.forEach(processor -> processor.processAchievementDeleted(event.getAchievementId()));
+    }
+
+    @EventListener
+    public void handleAchievementUpdatedEvent(AchievementUpdatedEvent event) {
+        processors.forEach(processor -> processor.processAchievementUpdated(event.getAchievementId()));
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/AchievementEventProcessor.java
+++ b/src/main/java/com/stempo/api/domain/application/event/AchievementEventProcessor.java
@@ -1,0 +1,8 @@
+package com.stempo.api.domain.application.event;
+
+public interface AchievementEventProcessor {
+
+    void processAchievementDeleted(Long achievementId);
+
+    void processAchievementUpdated(Long achievementId);
+}

--- a/src/main/java/com/stempo/api/domain/application/event/AchievementEventProcessorRegistry.java
+++ b/src/main/java/com/stempo/api/domain/application/event/AchievementEventProcessorRegistry.java
@@ -1,0 +1,21 @@
+package com.stempo.api.domain.application.event;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class AchievementEventProcessorRegistry {
+
+    private final List<AchievementEventProcessor> processors = new ArrayList<>();
+
+    public void register(AchievementEventProcessor processor) {
+        processors.add(processor);
+    }
+
+    public List<AchievementEventProcessor> getProcessors() {
+        return Collections.unmodifiableList(processors);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/AchievementUpdatedEvent.java
+++ b/src/main/java/com/stempo/api/domain/application/event/AchievementUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.stempo.api.domain.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class AchievementUpdatedEvent extends ApplicationEvent {
+
+    private final Long achievementId;
+
+    public AchievementUpdatedEvent(Object source, Long achievementId) {
+        super(source);
+        this.achievementId = achievementId;
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/UserAchievementEventProcessor.java
+++ b/src/main/java/com/stempo/api/domain/application/event/UserAchievementEventProcessor.java
@@ -1,0 +1,29 @@
+package com.stempo.api.domain.application.event;
+
+import com.stempo.api.domain.domain.model.UserAchievement;
+import com.stempo.api.domain.domain.repository.UserAchievementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserAchievementEventProcessor implements AchievementEventProcessor {
+
+    private final UserAchievementRepository userAchievementRepository;
+
+    @Override
+    @Transactional
+    public void processAchievementDeleted(Long achievementId) {
+        List<UserAchievement> achievements = userAchievementRepository.findByAchievementId(achievementId);
+        achievements.forEach(UserAchievement::delete);
+        userAchievementRepository.saveAll(achievements);
+    }
+
+    @Override
+    public void processAchievementUpdated(Long achievementId) {
+        // do nothing
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/service/AchievementService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/AchievementService.java
@@ -1,0 +1,18 @@
+package com.stempo.api.domain.application.service;
+
+import com.stempo.api.domain.presentation.dto.request.AchievementRequestDto;
+import com.stempo.api.domain.presentation.dto.request.AchievementUpdateRequestDto;
+import com.stempo.api.domain.presentation.dto.response.AchievementResponseDto;
+
+import java.util.List;
+
+public interface AchievementService {
+
+    Long registerAchievement(AchievementRequestDto requestDto);
+
+    List<AchievementResponseDto> getAchievements();
+
+    Long updateAchievement(Long achievementId, AchievementUpdateRequestDto requestDto);
+
+    Long deleteAchievement(Long achievementId);
+}

--- a/src/main/java/com/stempo/api/domain/application/service/AchievementServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/AchievementServiceImpl.java
@@ -1,0 +1,47 @@
+package com.stempo.api.domain.application.service;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import com.stempo.api.domain.domain.repository.AchievementRepository;
+import com.stempo.api.domain.presentation.dto.request.AchievementRequestDto;
+import com.stempo.api.domain.presentation.dto.request.AchievementUpdateRequestDto;
+import com.stempo.api.domain.presentation.dto.response.AchievementResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AchievementServiceImpl implements AchievementService {
+
+    private final AchievementRepository repository;
+
+
+    @Override
+    public Long registerAchievement(AchievementRequestDto requestDto) {
+        Achievement achievement = AchievementRequestDto.toDomain(requestDto);
+        return repository.save(achievement).getId();
+    }
+
+    @Override
+    public List<AchievementResponseDto> getAchievements() {
+        List<Achievement> achievements = repository.findAll();
+        return achievements.stream()
+                .map(AchievementResponseDto::toDto)
+                .toList();
+    }
+
+    @Override
+    public Long updateAchievement(Long achievementId, AchievementUpdateRequestDto requestDto) {
+        Achievement achievement = repository.findByIdOrThrow(achievementId);
+        achievement.update(requestDto);
+        return repository.save(achievement).getId();
+    }
+
+    @Override
+    public Long deleteAchievement(Long achievementId) {
+        Achievement achievement = repository.findByIdOrThrow(achievementId);
+        achievement.delete();
+        return repository.save(achievement).getId();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/service/AchievementServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/AchievementServiceImpl.java
@@ -1,11 +1,14 @@
 package com.stempo.api.domain.application.service;
 
+import com.stempo.api.domain.application.event.AchievementDeletedEvent;
+import com.stempo.api.domain.application.event.AchievementUpdatedEvent;
 import com.stempo.api.domain.domain.model.Achievement;
 import com.stempo.api.domain.domain.repository.AchievementRepository;
 import com.stempo.api.domain.presentation.dto.request.AchievementRequestDto;
 import com.stempo.api.domain.presentation.dto.request.AchievementUpdateRequestDto;
 import com.stempo.api.domain.presentation.dto.response.AchievementResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,7 +18,7 @@ import java.util.List;
 public class AchievementServiceImpl implements AchievementService {
 
     private final AchievementRepository repository;
-
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public Long registerAchievement(AchievementRequestDto requestDto) {
@@ -35,13 +38,17 @@ public class AchievementServiceImpl implements AchievementService {
     public Long updateAchievement(Long achievementId, AchievementUpdateRequestDto requestDto) {
         Achievement achievement = repository.findByIdOrThrow(achievementId);
         achievement.update(requestDto);
-        return repository.save(achievement).getId();
+        repository.save(achievement);
+        eventPublisher.publishEvent(new AchievementUpdatedEvent(this, achievement.getId()));
+        return achievement.getId();
     }
 
     @Override
     public Long deleteAchievement(Long achievementId) {
         Achievement achievement = repository.findByIdOrThrow(achievementId);
         achievement.delete();
-        return repository.save(achievement).getId();
+        repository.save(achievement);
+        eventPublisher.publishEvent(new AchievementDeletedEvent(this, achievement.getId()));
+        return achievement.getId();
     }
 }

--- a/src/main/java/com/stempo/api/domain/application/service/UserAchievementService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserAchievementService.java
@@ -1,0 +1,12 @@
+package com.stempo.api.domain.application.service;
+
+import com.stempo.api.domain.presentation.dto.response.UserAchievementResponseDto;
+
+import java.util.List;
+
+public interface UserAchievementService {
+
+    Long registerUserAchievement(Long achievementId);
+
+    List<UserAchievementResponseDto> getUserAchievements();
+}

--- a/src/main/java/com/stempo/api/domain/application/service/UserAchievementServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserAchievementServiceImpl.java
@@ -1,0 +1,49 @@
+package com.stempo.api.domain.application.service;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import com.stempo.api.domain.domain.model.UserAchievement;
+import com.stempo.api.domain.domain.repository.AchievementRepository;
+import com.stempo.api.domain.domain.repository.UserAchievementRepository;
+import com.stempo.api.domain.persistence.entity.UserAchievementEntity;
+import com.stempo.api.domain.presentation.dto.response.UserAchievementResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAchievementServiceImpl implements UserAchievementService {
+
+    private final UserService userService;
+    private final UserAchievementRepository userAchievementRepository;
+    private final AchievementRepository achievementRepository;
+
+    @Override
+    public Long registerUserAchievement(Long achievementId) {
+        String deviceTag = userService.getCurrentDeviceTag();
+        Optional<UserAchievementEntity> existingUserAchievement = userAchievementRepository.findByDeviceTagAndAchievementId(deviceTag, achievementId);
+
+        if (existingUserAchievement.isPresent()) {
+            return existingUserAchievement.get().getId();
+        }
+
+        UserAchievement userAchievement = UserAchievement.create(achievementId, deviceTag);
+        return userAchievementRepository.save(userAchievement).getId();
+    }
+
+    @Override
+    public List<UserAchievementResponseDto> getUserAchievements() {
+        String deviceTag = userService.getCurrentDeviceTag();
+        List<UserAchievementEntity> userAchievements = userAchievementRepository.findByDeviceTag(deviceTag);
+        return userAchievements.stream()
+                .map(this::getUserAchievementResponseDto)
+                .toList();
+    }
+
+    private UserAchievementResponseDto getUserAchievementResponseDto(UserAchievementEntity ua) {
+        Achievement achievement = achievementRepository.findByIdOrThrow(ua.getAchievementId());
+        return UserAchievementResponseDto.toDto(achievement);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/domain/model/Achievement.java
+++ b/src/main/java/com/stempo/api/domain/domain/model/Achievement.java
@@ -1,0 +1,35 @@
+package com.stempo.api.domain.domain.model;
+
+import com.stempo.api.domain.presentation.dto.request.AchievementUpdateRequestDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Optional;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Achievement {
+
+    private Long id;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private boolean deleted;
+
+    public void update(AchievementUpdateRequestDto requestDto) {
+        Optional.ofNullable(requestDto.getName()).ifPresent(this::setName);
+        Optional.ofNullable(requestDto.getDescription()).ifPresent(this::setDescription);
+        Optional.ofNullable(requestDto.getImageUrl()).ifPresent(this::setImageUrl);
+    }
+
+    public void delete() {
+        setDeleted(true);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/domain/model/UserAchievement.java
+++ b/src/main/java/com/stempo/api/domain/domain/model/UserAchievement.java
@@ -1,0 +1,30 @@
+package com.stempo.api.domain.domain.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserAchievement {
+
+    private Long id;
+    private String deviceTag;
+    private Long achievementId;
+    private LocalDateTime createdAt;
+
+    public static UserAchievement create(Long achievementId, String deviceTag) {
+        return UserAchievement.builder()
+                .achievementId(achievementId)
+                .deviceTag(deviceTag)
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/domain/model/UserAchievement.java
+++ b/src/main/java/com/stempo/api/domain/domain/model/UserAchievement.java
@@ -20,11 +20,16 @@ public class UserAchievement {
     private String deviceTag;
     private Long achievementId;
     private LocalDateTime createdAt;
+    private boolean deleted;
 
     public static UserAchievement create(Long achievementId, String deviceTag) {
         return UserAchievement.builder()
                 .achievementId(achievementId)
                 .deviceTag(deviceTag)
                 .build();
+    }
+
+    public void delete() {
+        setDeleted(true);
     }
 }

--- a/src/main/java/com/stempo/api/domain/domain/repository/AchievementRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/AchievementRepository.java
@@ -1,0 +1,14 @@
+package com.stempo.api.domain.domain.repository;
+
+import com.stempo.api.domain.domain.model.Achievement;
+
+import java.util.List;
+
+public interface AchievementRepository {
+
+    Achievement findByIdOrThrow(Long achievementId);
+
+    List<Achievement> findAll();
+
+    Achievement save(Achievement achievement);
+}

--- a/src/main/java/com/stempo/api/domain/domain/repository/UserAchievementRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/UserAchievementRepository.java
@@ -1,0 +1,16 @@
+package com.stempo.api.domain.domain.repository;
+
+import com.stempo.api.domain.domain.model.UserAchievement;
+import com.stempo.api.domain.persistence.entity.UserAchievementEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserAchievementRepository {
+
+    UserAchievement save(UserAchievement userAchievement);
+
+    List<UserAchievementEntity> findByDeviceTag(String deviceTag);
+
+    Optional<UserAchievementEntity> findByDeviceTagAndAchievementId(String deviceTag, Long achievementId);
+}

--- a/src/main/java/com/stempo/api/domain/domain/repository/UserAchievementRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/UserAchievementRepository.java
@@ -10,7 +10,11 @@ public interface UserAchievementRepository {
 
     UserAchievement save(UserAchievement userAchievement);
 
+    void saveAll(List<UserAchievement> achievements);
+
     List<UserAchievementEntity> findByDeviceTag(String deviceTag);
 
     Optional<UserAchievementEntity> findByDeviceTagAndAchievementId(String deviceTag, Long achievementId);
+
+    List<UserAchievement> findByAchievementId(Long achievementId);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/AchievementEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/AchievementEntity.java
@@ -36,4 +36,7 @@ public class AchievementEntity extends BaseEntity {
 
     @Column(nullable = false)
     private String imageUrl;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/ArticleEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/ArticleEntity.java
@@ -40,4 +40,7 @@ public class ArticleEntity extends BaseEntity {
     @Column(nullable = false)
     @URL(message = "Invalid URL")
     private String articleUrl;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/BaseEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/BaseEntity.java
@@ -24,9 +24,6 @@ public class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    @Column(nullable = false)
-    private boolean deleted = false;
-
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();

--- a/src/main/java/com/stempo/api/domain/persistence/entity/BoardEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/BoardEntity.java
@@ -44,4 +44,7 @@ public class BoardEntity extends BaseEntity {
     @Column(nullable = false)
     @Size(min = 1, max = 10000, message = "Content must be between 1 and 10000 characters")
     private String content;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/RecordEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/RecordEntity.java
@@ -34,4 +34,7 @@ public class RecordEntity extends BaseEntity {
 
     private Integer duration;
     private Integer steps;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/UploadedFileEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/UploadedFileEntity.java
@@ -40,4 +40,7 @@ public class UploadedFileEntity extends BaseEntity {
 
     @Column(nullable = false)
     private Long fileSize;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/UserAchievementEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/UserAchievementEntity.java
@@ -35,4 +35,7 @@ public class UserAchievementEntity extends BaseEntity {
 
     @Column(nullable = false)
     private Long achievementId;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/UserAchievementEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/UserAchievementEntity.java
@@ -1,0 +1,38 @@
+package com.stempo.api.domain.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "user_achievement", indexes = {
+        @Index(name = "idx_user_achievement_device_tag", columnList = "deviceTag"),
+        @Index(name = "idx_user_achievement_achievement_id", columnList = "achievementId")
+})
+public class UserAchievementEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String deviceTag;
+
+    @Column(nullable = false)
+    private Long achievementId;
+}

--- a/src/main/java/com/stempo/api/domain/persistence/entity/UserEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/UserEntity.java
@@ -31,4 +31,7 @@ public class UserEntity extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/entity/VideoEntity.java
+++ b/src/main/java/com/stempo/api/domain/persistence/entity/VideoEntity.java
@@ -40,4 +40,7 @@ public class VideoEntity extends BaseEntity {
     @Column(nullable = false)
     @URL(message = "Invalid URL")
     private String videoUrl;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/src/main/java/com/stempo/api/domain/persistence/mappper/AchievementMapper.java
+++ b/src/main/java/com/stempo/api/domain/persistence/mappper/AchievementMapper.java
@@ -1,0 +1,29 @@
+package com.stempo.api.domain.persistence.mappper;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import com.stempo.api.domain.persistence.entity.AchievementEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AchievementMapper {
+
+    public AchievementEntity toEntity(Achievement achievement) {
+        return AchievementEntity.builder()
+                .id(achievement.getId())
+                .name(achievement.getName())
+                .description(achievement.getDescription())
+                .imageUrl(achievement.getImageUrl())
+                .deleted(achievement.isDeleted())
+                .build();
+    }
+
+    public Achievement toDomain(AchievementEntity entity) {
+        return Achievement.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .imageUrl(entity.getImageUrl())
+                .deleted(entity.isDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/persistence/mappper/RecordMapper.java
+++ b/src/main/java/com/stempo/api/domain/persistence/mappper/RecordMapper.java
@@ -17,14 +17,14 @@ public class RecordMapper {
                 .build();
     }
 
-    public Record toDomain(RecordEntity recordEntity) {
+    public Record toDomain(RecordEntity entity) {
         return Record.builder()
-                .id(recordEntity.getId())
-                .deviceTag(recordEntity.getDeviceTag())
-                .accuracy(recordEntity.getAccuracy())
-                .duration(recordEntity.getDuration())
-                .steps(recordEntity.getSteps())
-                .createdAt(recordEntity.getCreatedAt())
+                .id(entity.getId())
+                .deviceTag(entity.getDeviceTag())
+                .accuracy(entity.getAccuracy())
+                .duration(entity.getDuration())
+                .steps(entity.getSteps())
+                .createdAt(entity.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/mappper/UserAchievementMapper.java
+++ b/src/main/java/com/stempo/api/domain/persistence/mappper/UserAchievementMapper.java
@@ -12,6 +12,7 @@ public class UserAchievementMapper {
                 .id(userAchievement.getId())
                 .deviceTag(userAchievement.getDeviceTag())
                 .achievementId(userAchievement.getAchievementId())
+                .deleted(userAchievement.isDeleted())
                 .build();
     }
 
@@ -21,6 +22,7 @@ public class UserAchievementMapper {
                 .deviceTag(userAchievementEntity.getDeviceTag())
                 .achievementId(userAchievementEntity.getAchievementId())
                 .createdAt(userAchievementEntity.getCreatedAt())
+                .deleted(userAchievementEntity.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/mappper/UserAchievementMapper.java
+++ b/src/main/java/com/stempo/api/domain/persistence/mappper/UserAchievementMapper.java
@@ -1,0 +1,26 @@
+package com.stempo.api.domain.persistence.mappper;
+
+import com.stempo.api.domain.domain.model.UserAchievement;
+import com.stempo.api.domain.persistence.entity.UserAchievementEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserAchievementMapper {
+
+    public UserAchievementEntity toEntity(UserAchievement userAchievement) {
+        return UserAchievementEntity.builder()
+                .id(userAchievement.getId())
+                .deviceTag(userAchievement.getDeviceTag())
+                .achievementId(userAchievement.getAchievementId())
+                .build();
+    }
+
+    public UserAchievement toDomain(UserAchievementEntity userAchievementEntity) {
+        return UserAchievement.builder()
+                .id(userAchievementEntity.getId())
+                .deviceTag(userAchievementEntity.getDeviceTag())
+                .achievementId(userAchievementEntity.getAchievementId())
+                .createdAt(userAchievementEntity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/AchievementJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/AchievementJpaRepository.java
@@ -1,0 +1,16 @@
+package com.stempo.api.domain.persistence.repository;
+
+import com.stempo.api.domain.persistence.entity.AchievementEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface AchievementJpaRepository extends JpaRepository<AchievementEntity, Long> {
+
+    @Query("SELECT a " +
+            "FROM AchievementEntity a " +
+            "WHERE a.deleted = false " +
+            "ORDER BY a.createdAt ASC")
+    List<AchievementEntity> findAllActiveAchievements();
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/AchievementJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/AchievementJpaRepository.java
@@ -3,8 +3,10 @@ package com.stempo.api.domain.persistence.repository;
 import com.stempo.api.domain.persistence.entity.AchievementEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AchievementJpaRepository extends JpaRepository<AchievementEntity, Long> {
 
@@ -13,4 +15,9 @@ public interface AchievementJpaRepository extends JpaRepository<AchievementEntit
             "WHERE a.deleted = false " +
             "ORDER BY a.createdAt ASC")
     List<AchievementEntity> findAllActiveAchievements();
+
+    @Query("SELECT a " +
+            "FROM AchievementEntity a " +
+            "WHERE a.id = :achievementId AND a.deleted = false")
+    Optional<AchievementEntity> findByIdAndNotDeleted(@Param("achievementId") Long achievementId);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/AchievementRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/AchievementRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.stempo.api.domain.persistence.repository;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import com.stempo.api.domain.domain.repository.AchievementRepository;
+import com.stempo.api.domain.persistence.entity.AchievementEntity;
+import com.stempo.api.domain.persistence.mappper.AchievementMapper;
+import com.stempo.api.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AchievementRepositoryImpl implements AchievementRepository {
+
+    private final AchievementJpaRepository repository;
+    private final AchievementMapper mapper;
+
+
+    @Override
+    public Achievement findByIdOrThrow(Long achievementId) {
+        AchievementEntity entity = repository.findById(achievementId)
+                .orElseThrow(() -> new NotFoundException("[Achievement] id: " + achievementId + " not found"));
+        return mapper.toDomain(entity);
+    }
+
+    @Override
+    public List<Achievement> findAll() {
+        List<AchievementEntity> entities = repository.findAllActiveAchievements();
+        return entities.stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Achievement save(Achievement achievement) {
+        AchievementEntity jpaEntity = mapper.toEntity(achievement);
+        AchievementEntity savedEntity = repository.save(jpaEntity);
+        return mapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/AchievementRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/AchievementRepositoryImpl.java
@@ -20,7 +20,7 @@ public class AchievementRepositoryImpl implements AchievementRepository {
 
     @Override
     public Achievement findByIdOrThrow(Long achievementId) {
-        AchievementEntity entity = repository.findById(achievementId)
+        AchievementEntity entity = repository.findByIdAndNotDeleted(achievementId)
                 .orElseThrow(() -> new NotFoundException("[Achievement] id: " + achievementId + " not found"));
         return mapper.toDomain(entity);
     }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementJpaRepository.java
@@ -2,13 +2,20 @@ package com.stempo.api.domain.persistence.repository;
 
 import com.stempo.api.domain.persistence.entity.UserAchievementEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface UserAchievementJpaRepository extends JpaRepository<UserAchievementEntity, Long> {
 
-    List<UserAchievementEntity> findByDeviceTagOrderByCreatedAtDesc(String deviceTag);
+    @Query("SELECT ua " +
+            "FROM UserAchievementEntity ua " +
+            "WHERE ua.deviceTag = :deviceTag AND ua.deleted = false " +
+            "ORDER BY ua.createdAt DESC")
+    List<UserAchievementEntity> findByDeviceTag(String deviceTag);
 
     Optional<UserAchievementEntity> findByDeviceTagAndAchievementId(String deviceTag, Long achievementId);
+
+    List<UserAchievementEntity> findByAchievementId(Long achievementId);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementJpaRepository.java
@@ -1,0 +1,14 @@
+package com.stempo.api.domain.persistence.repository;
+
+import com.stempo.api.domain.persistence.entity.UserAchievementEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserAchievementJpaRepository extends JpaRepository<UserAchievementEntity, Long> {
+
+    List<UserAchievementEntity> findByDeviceTagOrderByCreatedAtDesc(String deviceTag);
+
+    Optional<UserAchievementEntity> findByDeviceTagAndAchievementId(String deviceTag, Long achievementId);
+}

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementRepositoryImpl.java
@@ -25,12 +25,28 @@ public class UserAchievementRepositoryImpl implements UserAchievementRepository 
     }
 
     @Override
+    public void saveAll(List<UserAchievement> achievements) {
+        List<UserAchievementEntity> jpaEntities = achievements.stream()
+                .map(mapper::toEntity)
+                .toList();
+        repository.saveAll(jpaEntities);
+    }
+
+    @Override
     public List<UserAchievementEntity> findByDeviceTag(String deviceTag) {
-        return repository.findByDeviceTagOrderByCreatedAtDesc(deviceTag);
+        return repository.findByDeviceTag(deviceTag);
     }
 
     @Override
     public Optional<UserAchievementEntity> findByDeviceTagAndAchievementId(String deviceTag, Long achievementId) {
         return repository.findByDeviceTagAndAchievementId(deviceTag, achievementId);
+    }
+
+    @Override
+    public List<UserAchievement> findByAchievementId(Long achievementId) {
+        List<UserAchievementEntity> jpaEntities = repository.findByAchievementId(achievementId);
+        return jpaEntities.stream()
+                .map(mapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UserAchievementRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.stempo.api.domain.persistence.repository;
+
+import com.stempo.api.domain.domain.model.UserAchievement;
+import com.stempo.api.domain.domain.repository.UserAchievementRepository;
+import com.stempo.api.domain.persistence.entity.UserAchievementEntity;
+import com.stempo.api.domain.persistence.mappper.UserAchievementMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserAchievementRepositoryImpl implements UserAchievementRepository {
+
+    private final UserAchievementJpaRepository repository;
+    private final UserAchievementMapper mapper;
+
+    @Override
+    public UserAchievement save(UserAchievement userAchievement) {
+        UserAchievementEntity jpaEntity = mapper.toEntity(userAchievement);
+        UserAchievementEntity savedEntity = repository.save(jpaEntity);
+        return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<UserAchievementEntity> findByDeviceTag(String deviceTag) {
+        return repository.findByDeviceTagOrderByCreatedAtDesc(deviceTag);
+    }
+
+    @Override
+    public Optional<UserAchievementEntity> findByDeviceTagAndAchievementId(String deviceTag, Long achievementId) {
+        return repository.findByDeviceTagAndAchievementId(deviceTag, achievementId);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/presentation/AchievementController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/AchievementController.java
@@ -1,0 +1,69 @@
+package com.stempo.api.domain.presentation;
+
+import com.stempo.api.domain.application.service.AchievementService;
+import com.stempo.api.domain.presentation.dto.request.AchievementRequestDto;
+import com.stempo.api.domain.presentation.dto.request.AchievementUpdateRequestDto;
+import com.stempo.api.domain.presentation.dto.response.AchievementResponseDto;
+import com.stempo.api.global.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Achievement", description = "업적")
+public class AchievementController {
+
+    private final AchievementService achievementService;
+
+    @Operation(summary = "[A] 업적 추가", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @Secured({ "ROLE_ADMIN" })
+    @PostMapping("/api/v1/achievements")
+    public ApiResponse<Long> registerAchievement(
+            @Valid @RequestBody AchievementRequestDto requestDto
+    ) {
+        Long id = achievementService.registerAchievement(requestDto);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "[U] 업적 목록 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @GetMapping("/api/v1/achievements")
+    public ApiResponse<List<AchievementResponseDto>> getAchievements() {
+        List<AchievementResponseDto> achievements = achievementService.getAchievements();
+        return ApiResponse.success(achievements);
+    }
+
+    @Operation(summary = "[A] 업적 수정", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @Secured({ "ROLE_ADMIN" })
+    @PatchMapping("/api/v1/achievements/{achievementId}")
+    public ApiResponse<Long> updateAchievement(
+            @PathVariable(name = "achievementId") Long achievementId,
+            @Valid @RequestBody AchievementUpdateRequestDto requestDto
+    ) {
+        Long id = achievementService.updateAchievement(achievementId, requestDto);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "[A] 업적 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @Secured({ "ROLE_ADMIN" })
+    @DeleteMapping("/api/v1/achievements/{achievementId}")
+    public ApiResponse<Long> deleteAchievement(
+            @PathVariable(name = "achievementId") Long achievementId
+    ) {
+        Long id = achievementService.deleteAchievement(achievementId);
+        return ApiResponse.success(id);
+    }
+
+}

--- a/src/main/java/com/stempo/api/domain/presentation/UserAchievementController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/UserAchievementController.java
@@ -1,0 +1,41 @@
+package com.stempo.api.domain.presentation;
+
+import com.stempo.api.domain.application.service.UserAchievementService;
+import com.stempo.api.domain.presentation.dto.response.UserAchievementResponseDto;
+import com.stempo.api.global.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Achievement - User", description = "유저 업적")
+public class UserAchievementController {
+
+    private final UserAchievementService userAchievementService;
+
+    @Operation(summary = "[U] 유저 업적 등록", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PostMapping("/api/v1/achievements/user/{achievementId}")
+    public ApiResponse<Long> registerUserAchievement(
+            @PathVariable(name = "achievementId") Long achievementId
+    ) {
+        Long id = userAchievementService.registerUserAchievement(achievementId);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "[U] 내 업적 조회", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @GetMapping("/api/v1/achievements/user")
+    public ApiResponse<List<UserAchievementResponseDto>> getUserAchievements() {
+        List<UserAchievementResponseDto> myAchievements = userAchievementService.getUserAchievements();
+        return ApiResponse.success(myAchievements);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/AchievementRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/AchievementRequestDto.java
@@ -1,0 +1,32 @@
+package com.stempo.api.domain.presentation.dto.request;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AchievementRequestDto {
+
+    @NotNull
+    @Schema(description = "업적 이름", example = "업적 이름", minLength = 1, maxLength = 100)
+    private String name;
+
+    @NotNull
+    @Schema(description = "업적 설명", example = "업적 설명", minLength = 1, maxLength = 255)
+    private String description;
+
+    @NotNull
+    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg", minLength = 1, maxLength = 255)
+    private String imageUrl;
+
+    public static Achievement toDomain(AchievementRequestDto requestDto) {
+        return Achievement.builder()
+                .name(requestDto.getName())
+                .description(requestDto.getDescription())
+                .imageUrl(requestDto.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/AchievementUpdateRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/AchievementUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.stempo.api.domain.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AchievementUpdateRequestDto {
+
+    @Schema(description = "업적 이름", example = "업적 이름", minLength = 1, maxLength = 100)
+    private String name;
+
+    @Schema(description = "업적 설명", example = "업적 설명", minLength = 1, maxLength = 255)
+    private String description;
+
+    @Schema(description = "이미지 URL", example = "https://example.com/image.jpg", minLength = 1, maxLength = 255)
+    private String imageUrl;
+}

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/AchievementResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/AchievementResponseDto.java
@@ -1,0 +1,24 @@
+package com.stempo.api.domain.presentation.dto.response;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AchievementResponseDto {
+
+    private Long id;
+    private String name;
+    private String description;
+    private String imageUrl;
+
+    public static AchievementResponseDto toDto(Achievement achievement) {
+        return AchievementResponseDto.builder()
+                .id(achievement.getId())
+                .name(achievement.getName())
+                .description(achievement.getDescription())
+                .imageUrl(achievement.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/UserAchievementResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/UserAchievementResponseDto.java
@@ -1,0 +1,22 @@
+package com.stempo.api.domain.presentation.dto.response;
+
+import com.stempo.api.domain.domain.model.Achievement;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserAchievementResponseDto {
+
+    private final String name;
+    private final String description;
+    private final String imageUrl;
+
+    public static UserAchievementResponseDto toDto(Achievement achievement) {
+        return UserAchievementResponseDto.builder()
+                .name(achievement.getName())
+                .description(achievement.getDescription())
+                .imageUrl(achievement.getImageUrl())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

> #15 

이번 PR은 Stempo 애플리케이션에서 사용자의 업적을 기록하고 조회하는 기능을 구현하는 작업입니다.
이 기능은 사용자가 달성한 업적을 체계적으로 기록하고, 이를 조회할 수 있도록 하여 동기부여와 성취감을 제공합니다.

## Tasks

- 업적 CRUD API 추가
- 사용자가 달성한 업적의 이름과 사진을 기록하는 기능 구현
- 사용자가 달성한 업적을 조회할 수 있는 기능 구현