### PR TITLE
feat: 비트에 박자의 다양성 추가 완료

### DIFF
--- a/create_rhythm.py
+++ b/create_rhythm.py
@@ -1,65 +1,48 @@
 import os
-import sys
 
+import sys
 from pydub import AudioSegment
 from pydub.generators import Sine
 
 
 # 메트로놈 비트 생성
-def create_metronome_bpm(bpm, tone_duration=100):
+def create_metronome_bpm(bpm, bit, tone_duration=100):
     frequency = 440.0  # 메트로놈 주파수
-    sine_wave = Sine(frequency)
+    sine_wave_strong = Sine(frequency)  # 강한 첫 박자
+    sine_wave_weak = Sine(frequency * 0.6)  # 약한 박자
 
     interval_ms = (60 / bpm) * 1000  # 비트 간의 간격 계산
 
-    tone = sine_wave.to_audio_segment(duration=tone_duration)  # 비트 길이
+    # 첫 박자는 강하게, 나머지는 약하게
+    strong_tone = sine_wave_strong.to_audio_segment(duration=tone_duration)  # 첫 박자
+    weak_tone = sine_wave_weak.to_audio_segment(duration=tone_duration)  # 나머지 박자
+
     silence = AudioSegment.silent(duration=interval_ms - tone_duration)  # 비트 간의 정적
 
-    return tone + silence  # 비트와 정적 결합
-
-# 리드미컬한 큐잉 생성
-def create_keyboard_rhythm(bpm, tone_duration=100):
-    frequency = 440.0  # 키보드 주파수
-    sine_wave = Sine(frequency)
-
-    interval_ms = (60 / bpm) * 1000  # 비트 간격
-    tone = sine_wave.to_audio_segment(duration=tone_duration)  # 키보드 톤
-    silence = AudioSegment.silent(duration=interval_ms - tone_duration)  # 정적 구간
-
-    rhythm = AudioSegment.empty()
-    for _ in range(10):  # 10번 반복
-        rhythm += tone + silence  # 리듬 패턴 생성
+    # 비트 패턴 생성
+    rhythm = strong_tone + silence
+    for _ in range(1, bit):  # 첫 박자 이후 약한 박자들 추가
+        rhythm += weak_tone + silence
 
     return rhythm
 
-# 메트로놈 비트와 리드미컬한 큐잉 결합
-def create_combined_rhythm(bpm):
-    metronome = create_metronome_bpm(bpm)  # 메트로놈 비트 생성
-    keyboard_rhythm = create_keyboard_rhythm(bpm)  # 키보드 리듬 생성
-
-    combined_rhythm = AudioSegment.empty()
-    for _ in range(10):  # 10번 반복
-        combined_rhythm += metronome  # 메트로놈 추가
-        combined_rhythm += keyboard_rhythm  # 키보드 리듬 추가
-
-    return combined_rhythm  # 결합된 리듬 반환
-
 # 리듬 생성 및 파일 저장
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python create_rhythm.py <bpm>")
+    if len(sys.argv) < 3:
+        print("Usage: python create_rhythm.py <bpm> <bit>")
         return
 
     bpm = int(sys.argv[1])  # BPM 입력
+    bit = int(sys.argv[2])  # 비트 수 입력
 
     output_dir = os.path.join(os.getcwd(), "generated")  # 출력 디렉토리 설정
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)  # 디렉토리 생성
 
-    output_filename = f"rhythm_{bpm}_bpm.wav"  # 파일 이름
+    output_filename = f"rhythm_{bpm}_{bit}_bpm.wav"  # 파일 이름
     output_path = os.path.join(output_dir, output_filename)  # 파일 경로
 
-    combined_rhythm = create_combined_rhythm(bpm)  # 메트로놈과 키보드 결합
+    combined_rhythm = create_metronome_bpm(bpm, bit)  # 비트에 맞는 리듬 생성
     combined_rhythm.export(output_path, format="wav")  # 파일로 저장
 
     print(f"Rhythm created: {output_path}")

--- a/src/main/java/com/stempo/api/domain/application/service/RhythmService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/RhythmService.java
@@ -1,5 +1,7 @@
 package com.stempo.api.domain.application.service;
 
+import com.stempo.api.domain.presentation.dto.request.RhythmRequestDto;
+
 public interface RhythmService {
-    String createRhythm(int bpm);
+    String createRhythm(RhythmRequestDto requestDto);
 }

--- a/src/main/java/com/stempo/api/domain/presentation/RhythmController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RhythmController.java
@@ -20,7 +20,8 @@ public class RhythmController {
     private final RhythmService rhythmService;
 
     @Operation(summary = "[U] 리듬 생성", description = "ROLE_USER 이상의 권한이 필요함<br>" +
-            "BPM은 10 이상 200 이하의 값이어야 함")
+            "BPM은 10 이상 200 이하의 값이어야 함<br>" +
+            "Bit는 1 이상 8 이하의 값이어야 함")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/rhythm")
     public ApiResponse<String> generateRhythm(

--- a/src/main/java/com/stempo/api/domain/presentation/RhythmController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RhythmController.java
@@ -1,13 +1,15 @@
 package com.stempo.api.domain.presentation;
 
 import com.stempo.api.domain.application.service.RhythmService;
+import com.stempo.api.domain.presentation.dto.request.RhythmRequestDto;
 import com.stempo.api.global.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,11 +22,11 @@ public class RhythmController {
     @Operation(summary = "[U] 리듬 생성", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "BPM은 10 이상 200 이하의 값이어야 함")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
-    @PostMapping("/api/v1/rhythm/{bpm}")
+    @PostMapping("/api/v1/rhythm")
     public ApiResponse<String> generateRhythm(
-            @PathVariable(name = "bpm") int bpm
+            @Valid @RequestBody RhythmRequestDto requestDto
     ) {
-        String filePath = rhythmService.createRhythm(bpm);
+        String filePath = rhythmService.createRhythm(requestDto);
         return ApiResponse.success(filePath);
     }
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/RhythmRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/RhythmRequestDto.java
@@ -12,11 +12,11 @@ public class RhythmRequestDto {
 
     @NotNull(message = "BPM is required")
     @Range(min = 10, max = 200, message = "BPM must be between 10 and 200")
-    @Schema(description = "BPM", example = "60")
+    @Schema(description = "BPM", example = "60", minimum = "10", maximum = "200")
     private Integer bpm;
 
     @NotNull(message = "Bit is required")
     @Range(min = 1, max = 8, message = "Bit must be between 1 and 8")
-    @Schema(description = "Bit", example = "4")
+    @Schema(description = "Bit", example = "4", minimum = "1", maximum = "8")
     private Integer bit;
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/RhythmRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/RhythmRequestDto.java
@@ -1,0 +1,22 @@
+package com.stempo.api.domain.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Range;
+
+@Getter
+@Setter
+public class RhythmRequestDto {
+
+    @NotNull(message = "BPM is required")
+    @Range(min = 10, max = 200, message = "BPM must be between 10 and 200")
+    @Schema(description = "BPM", example = "60")
+    private Integer bpm;
+
+    @NotNull(message = "Bit is required")
+    @Range(min = 1, max = 8, message = "Bit must be between 1 and 8")
+    @Schema(description = "Bit", example = "4")
+    private Integer bit;
+}


### PR DESCRIPTION
## Summary

> #30 

박자 옵션을 추가하고, 각 비트의 첫 박자만 강하게 출력되도록 리듬 생성 로직을 수정하였습니다.
리듬 파일은 비트의 길이만큼만 생성됩니다.

## Tasks

- 2비트, 3비트, 4비트, 6비트, 8비트 리듬 옵션 추가
- 각 비트의 첫 박자만 강하게 출력되도록 리듬 생성 로직 수정
- 선택된 비트에 맞는 리듬 파일 생성 및 제공 기능 추가
- 리듬 변경에 따른 테스트 및 최적화 작업 완료

## ETC

- 리듬 생성 로직 최적화 작업을 추가적으로 진행했습니다.
- 리듬 파일 생성 속도 및 정확도 개선을 위한 개선 사항이 포함되었습니다.