### PR TITLE
refactor: 비트 소리 크기 조정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	// Spring Project
 	implementation 'org.springframework.boot:spring-boot-starter-web' // 웹 MVC
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // 유효성 검사
-	developmentOnly 'org.springframework.boot:spring-boot-devtools' // 개발 도구
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security' // Spring Security

--- a/create_rhythm.py
+++ b/create_rhythm.py
@@ -1,12 +1,11 @@
 import os
-
 import sys
 from pydub import AudioSegment
 from pydub.generators import Sine
 
 
 # 메트로놈 비트 생성
-def create_metronome_bpm(bpm, bit, tone_duration=100):
+def create_metronome_bpm(bpm, bit, tone_duration=100, volume_factor=1.5):  # 볼륨 배수 기본값 1.5
     frequency = 440.0  # 메트로놈 주파수
     sine_wave_strong = Sine(frequency)  # 강한 첫 박자
     sine_wave_weak = Sine(frequency * 0.6)  # 약한 박자
@@ -18,6 +17,13 @@ def create_metronome_bpm(bpm, bit, tone_duration=100):
     weak_tone = sine_wave_weak.to_audio_segment(duration=tone_duration)  # 나머지 박자
 
     silence = AudioSegment.silent(duration=interval_ms - tone_duration)  # 비트 간의 정적
+
+    # 볼륨을 데시벨로 변환 (10 * log10(volume_factor))
+    volume_increase_db = 10 * (volume_factor ** 0.5)
+
+    # 볼륨 조절 (데시벨 단위로 증폭)
+    strong_tone = strong_tone + volume_increase_db
+    weak_tone = weak_tone + volume_increase_db
 
     # 비트 패턴 생성
     rhythm = strong_tone + silence


### PR DESCRIPTION
## Summary

> #45 

메트로놈 비트의 소리를 기존 대비 1.5배 증가시켰습니다.

## Tasks

- 리듬 생성 시 사용하는 사운드 파일의 볼륨을 증가시켜 소리 크기 조정
- 볼륨 조정 후 사운드 테스트 및 사용자 경험 최적화