### PR TITLE
fix: 내 재활 운동 기록 조회 API에서 타인의 데이터가 같이 불러와지는 문제 수정 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/service/RecordServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/RecordServiceImpl.java
@@ -28,14 +28,15 @@ public class RecordServiceImpl implements RecordService {
 
     @Override
     public List<RecordResponseDto> getRecordsByDateRange(LocalDate startDate, LocalDate endDate) {
+        String deviceTag = userService.getCurrentDeviceTag();
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atStartOfDay().plusDays(1);
 
         // startDateTime 이전의 가장 최신 데이터 가져오기
-        Record latestBeforeStartDate = recordRepository.findLatestBeforeStartDate(startDateTime);
+        Record latestBeforeStartDate = recordRepository.findLatestBeforeStartDate(deviceTag, startDateTime);
 
         // startDateTime과 endDateTime 사이의 데이터 가져오기
-        List<Record> records = recordRepository.findByDateBetween(startDateTime, endDateTime);
+        List<Record> records = recordRepository.findByDateBetween(deviceTag, startDateTime, endDateTime);
 
         // 결과 합치기
         List<RecordResponseDto> combinedRecords = new ArrayList<>();

--- a/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
@@ -9,7 +9,7 @@ public interface RecordRepository {
 
     Record save(Record record);
 
-    List<Record> findByDateBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<Record> findByDateBetween(String deviceTag, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
-    Record findLatestBeforeStartDate(LocalDateTime startDateTime);
+    Record findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordJpaRepository.java
@@ -14,8 +14,10 @@ public interface RecordJpaRepository extends JpaRepository<RecordEntity, Long> {
     @Query("SELECT r " +
             "FROM RecordEntity r " +
             "WHERE r.createdAt BETWEEN :startDateTime AND :endDateTime " +
+            "AND r.deviceTag = :deviceTag " +
             "ORDER BY r.createdAt ASC")
     List<RecordEntity> findByDateBetween(
+            @Param("deviceTag") String deviceTag,
             @Param("startDateTime") LocalDateTime startDateTime,
             @Param("endDateTime") LocalDateTime endDateTime
     );
@@ -23,9 +25,11 @@ public interface RecordJpaRepository extends JpaRepository<RecordEntity, Long> {
     @Query("SELECT r " +
             "FROM RecordEntity r " +
             "WHERE r.createdAt < :startDateTime " +
+            "AND r.deviceTag = :deviceTag " +
             "ORDER BY r.createdAt DESC " +
             "LIMIT 1")
     Optional<RecordEntity> findLatestBeforeStartDate(
+            @Param("deviceTag") String deviceTag,
             @Param("startDateTime") LocalDateTime startDateTime
     );
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
@@ -26,16 +26,16 @@ public class RecordRepositoryImpl implements RecordRepository {
     }
 
     @Override
-    public List<Record> findByDateBetween(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        List<RecordEntity> jpaEntities = repository.findByDateBetween(startDateTime, endDateTime);
+    public List<Record> findByDateBetween(String deviceTag, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        List<RecordEntity> jpaEntities = repository.findByDateBetween(deviceTag, startDateTime, endDateTime);
         return jpaEntities.stream()
                 .map(mapper::toDomain)
                 .toList();
     }
 
     @Override
-    public Record findLatestBeforeStartDate(LocalDateTime startDateTime) {
-        Optional<RecordEntity> jpaEntity = repository.findLatestBeforeStartDate(startDateTime);
+    public Record findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime) {
+        Optional<RecordEntity> jpaEntity = repository.findLatestBeforeStartDate(deviceTag, startDateTime);
         return jpaEntity.map(mapper::toDomain)
                 .orElse(null);
     }


### PR DESCRIPTION
## Summary

> #43 

재활 운동 기록 조회 API에서 타인의 데이터가 불러와지는 문제를 수정합니다.

## Tasks

- 재활 운동 기록 조회 시 사용자 인증을 기반으로 본인의 기록만 조회되도록 필터링 로직 수정