### PR TITLE
feat: 회원 탈퇴 API 추가 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/event/BoardEventProcessor.java
+++ b/src/main/java/com/stempo/api/domain/application/event/BoardEventProcessor.java
@@ -1,0 +1,30 @@
+package com.stempo.api.domain.application.event;
+
+import com.stempo.api.domain.domain.model.Board;
+import com.stempo.api.domain.domain.repository.BoardRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BoardEventProcessor implements UserEventProcessor {
+
+    private final BoardRepository boardRepository;
+    private final UserEventProcessorRegistry processorRegistry;
+
+    @PostConstruct
+    public void init() {
+        processorRegistry.register(this);
+    }
+
+    @Override
+    @Transactional
+    public void processUserDeleted(String deviceTag) {
+        List<Board> boards = boardRepository.findByDeviceTag(deviceTag);
+        boardRepository.deleteAll(boards);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/HomeworkEventProcessor.java
+++ b/src/main/java/com/stempo/api/domain/application/event/HomeworkEventProcessor.java
@@ -1,0 +1,30 @@
+package com.stempo.api.domain.application.event;
+
+import com.stempo.api.domain.domain.model.Homework;
+import com.stempo.api.domain.domain.repository.HomeworkRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class HomeworkEventProcessor implements UserEventProcessor {
+
+    private final HomeworkRepository homeworkRepository;
+    private final UserEventProcessorRegistry processorRegistry;
+
+    @PostConstruct
+    public void init() {
+        processorRegistry.register(this);
+    }
+
+    @Override
+    @Transactional
+    public void processUserDeleted(String deviceTag) {
+        List<Homework> records = homeworkRepository.findByDeviceTag(deviceTag);
+        homeworkRepository.deleteAll(records);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/RecordEventProcessor.java
+++ b/src/main/java/com/stempo/api/domain/application/event/RecordEventProcessor.java
@@ -1,0 +1,30 @@
+package com.stempo.api.domain.application.event;
+
+import com.stempo.api.domain.domain.model.Record;
+import com.stempo.api.domain.domain.repository.RecordRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RecordEventProcessor implements UserEventProcessor {
+
+    private final RecordRepository recordRepository;
+    private final UserEventProcessorRegistry processorRegistry;
+
+    @PostConstruct
+    public void init() {
+        processorRegistry.register(this);
+    }
+
+    @Override
+    @Transactional
+    public void processUserDeleted(String deviceTag) {
+        List<Record> records = recordRepository.findByDeviceTag(deviceTag);
+        recordRepository.deleteAll(records);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/UserDeletedEvent.java
+++ b/src/main/java/com/stempo/api/domain/application/event/UserDeletedEvent.java
@@ -1,0 +1,15 @@
+package com.stempo.api.domain.application.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UserDeletedEvent extends ApplicationEvent {
+
+    private final String deviceTag;
+
+    public UserDeletedEvent(Object source, String deviceTag) {
+        super(source);
+        this.deviceTag = deviceTag;
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/UserEventDispatcher.java
+++ b/src/main/java/com/stempo/api/domain/application/event/UserEventDispatcher.java
@@ -1,0 +1,19 @@
+package com.stempo.api.domain.application.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventDispatcher {
+
+    private final List<UserEventProcessor> processors;
+
+    @EventListener
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        processors.forEach(processor -> processor.processUserDeleted(event.getDeviceTag()));
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/event/UserEventProcessor.java
+++ b/src/main/java/com/stempo/api/domain/application/event/UserEventProcessor.java
@@ -1,0 +1,6 @@
+package com.stempo.api.domain.application.event;
+
+public interface UserEventProcessor {
+
+    void processUserDeleted(String deviceTag);
+}

--- a/src/main/java/com/stempo/api/domain/application/event/UserEventProcessorRegistry.java
+++ b/src/main/java/com/stempo/api/domain/application/event/UserEventProcessorRegistry.java
@@ -1,0 +1,21 @@
+package com.stempo.api.domain.application.event;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class UserEventProcessorRegistry {
+
+    private final List<UserEventProcessor> processors = new ArrayList<>();
+
+    public void register(UserEventProcessor processor) {
+        processors.add(processor);
+    }
+
+    public List<UserEventProcessor> getProcessors() {
+        return Collections.unmodifiableList(processors);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/service/AchievementServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/AchievementServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,18 +23,21 @@ public class AchievementServiceImpl implements AchievementService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
+    @Transactional
     public Long registerAchievement(AchievementRequestDto requestDto) {
         Achievement achievement = AchievementRequestDto.toDomain(requestDto);
         return repository.save(achievement).getId();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PagedResponseDto<AchievementResponseDto> getAchievements(Pageable pageable) {
         Page<Achievement> achievements = repository.findAll(pageable);
         return new PagedResponseDto<>(achievements.map(AchievementResponseDto::toDto));
     }
 
     @Override
+    @Transactional
     public Long updateAchievement(Long achievementId, AchievementUpdateRequestDto requestDto) {
         Achievement achievement = repository.findByIdOrThrow(achievementId);
         achievement.update(requestDto);
@@ -43,6 +47,7 @@ public class AchievementServiceImpl implements AchievementService {
     }
 
     @Override
+    @Transactional
     public Long deleteAchievement(Long achievementId) {
         Achievement achievement = repository.findByIdOrThrow(achievementId);
         achievement.delete();

--- a/src/main/java/com/stempo/api/domain/application/service/ArticleServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/ArticleServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,24 +20,28 @@ public class ArticleServiceImpl implements ArticleService {
     private final ArticleRepository repository;
 
     @Override
+    @Transactional
     public Long registerArticle(ArticleRequestDto requestDto) {
         Article article = ArticleRequestDto.toDomain(requestDto);
         return repository.save(article).getId();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PagedResponseDto<ArticleResponseDto> getArticles(Pageable pageable) {
         Page<Article> articles = repository.findAll(pageable);
         return new PagedResponseDto<>(articles.map(ArticleResponseDto::toDto));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ArticleDetailsResponseDto getArticle(Long articleId) {
         Article article = repository.findByIdOrThrow(articleId);
         return ArticleDetailsResponseDto.toDto(article);
     }
 
     @Override
+    @Transactional
     public Long updateArticle(Long articleId, ArticleUpdateRequestDto requestDto) {
         Article article = repository.findByIdOrThrow(articleId);
         article.update(requestDto);
@@ -44,6 +49,7 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
+    @Transactional
     public Long deleteArticle(Long articleId) {
         Article article = repository.findByIdOrThrow(articleId);
         article.delete();

--- a/src/main/java/com/stempo/api/domain/application/service/AuthService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/AuthService.java
@@ -8,6 +8,8 @@ public interface AuthService {
 
     TokenInfo registerUser(AuthRequestDto requestDto);
 
+    String unregisterUser();
+
     TokenInfo login(AuthRequestDto requestDto);
 
     TokenInfo reissueToken(HttpServletRequest request);

--- a/src/main/java/com/stempo/api/domain/application/service/BoardServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/BoardServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class BoardServiceImpl implements BoardService {
     private final BoardRepository repository;
 
     @Override
+    @Transactional
     public Long registerBoard(BoardRequestDto requestDto) {
         User user = userService.getCurrentUser();
         Board board = BoardRequestDto.toDomain(requestDto, user.getDeviceTag());
@@ -30,6 +32,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PagedResponseDto<BoardResponseDto> getBoardsByCategory(BoardCategory category, Pageable pageable) {
         validateAccessPermissionForSuggestion(category);
         Page<Board> boards = repository.findByCategory(category, pageable);
@@ -37,6 +40,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
+    @Transactional
     public Long updateBoard(Long boardId, BoardUpdateRequestDto requestDto) {
         User user = userService.getCurrentUser();
         Board board = repository.findByIdOrThrow(boardId);
@@ -46,6 +50,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
+    @Transactional
     public Long deleteBoard(Long boardId) {
         User user = userService.getCurrentUser();
         Board board = repository.findByIdOrThrow(boardId);

--- a/src/main/java/com/stempo/api/domain/application/service/HomeworkServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/HomeworkServiceImpl.java
@@ -19,31 +19,31 @@ public class HomeworkServiceImpl implements HomeworkService {
     private final UserService userService;
     private final HomeworkRepository repository;
 
-    @Transactional
     @Override
+    @Transactional
     public Long addHomework(HomeworkRequestDto requestDto) {
         String deviceTag = userService.getCurrentDeviceTag();
         Homework homework = HomeworkRequestDto.toDomain(requestDto, deviceTag);
         return repository.save(homework).getId();
     }
 
-    @Transactional(readOnly = true)
     @Override
+    @Transactional(readOnly = true)
     public PagedResponseDto<HomeworkResponseDto> getHomeworks(Boolean completed, Pageable pageable) {
         Page<Homework> homeworks = repository.findByCompleted(completed, pageable);
         return new PagedResponseDto<>(homeworks.map(HomeworkResponseDto::toDto));
     }
 
-    @Transactional
     @Override
+    @Transactional
     public Long updateHomework(Long homeworkId, HomeworkUpdateRequestDto requestDto) {
         Homework homework = repository.findByIdOrThrow(homeworkId);
         homework.update(requestDto);
         return repository.save(homework).getId();
     }
 
-    @Transactional
     @Override
+    @Transactional
     public Long deleteHomework(Long homeworkId) {
         Homework homework = repository.findByIdOrThrow(homeworkId);
         repository.delete(homework);

--- a/src/main/java/com/stempo/api/domain/application/service/RecordServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/RecordServiceImpl.java
@@ -6,6 +6,7 @@ import com.stempo.api.domain.presentation.dto.request.RecordRequestDto;
 import com.stempo.api.domain.presentation.dto.response.RecordResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class RecordServiceImpl implements RecordService {
     private final RecordRepository recordRepository;
 
     @Override
+    @Transactional
     public String record(RecordRequestDto requestDto) {
         String deviceTag = userService.getCurrentDeviceTag();
         Record record = RecordRequestDto.toDomain(requestDto, deviceTag);
@@ -27,6 +29,7 @@ public class RecordServiceImpl implements RecordService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<RecordResponseDto> getRecordsByDateRange(LocalDate startDate, LocalDate endDate) {
         String deviceTag = userService.getCurrentDeviceTag();
         LocalDateTime startDateTime = startDate.atStartOfDay();

--- a/src/main/java/com/stempo/api/domain/application/service/RhythmServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/RhythmServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -30,6 +31,7 @@ public class RhythmServiceImpl implements RhythmService {
     private String scriptPath;
 
     @Override
+    @Transactional
     public String createRhythm(RhythmRequestDto requestDto) {
         int bpm = requestDto.getBpm();
         int bit = requestDto.getBit();

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
@@ -4,6 +4,7 @@ import com.stempo.api.domain.domain.model.UploadedFile;
 import com.stempo.api.domain.domain.repository.UploadedFileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -14,11 +15,13 @@ public class UploadedFileServiceImpl implements UploadedFileService {
     private final UploadedFileRepository uploadedFileRepository;
 
     @Override
+    @Transactional
     public UploadedFile saveUploadedFile(UploadedFile uploadedFile) {
         return uploadedFileRepository.save(uploadedFile);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Optional<UploadedFile> getUploadedFileByOriginalFileName(String fileName) {
         return uploadedFileRepository.findByOriginalFileName(fileName);
     }

--- a/src/main/java/com/stempo/api/domain/application/service/UserAchievementServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserAchievementServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
@@ -25,6 +26,7 @@ public class UserAchievementServiceImpl implements UserAchievementService {
     private final AchievementRepository achievementRepository;
 
     @Override
+    @Transactional
     public Long registerUserAchievement(Long achievementId) {
         String deviceTag = userService.getCurrentDeviceTag();
         Optional<UserAchievement> existingUserAchievement =
@@ -39,6 +41,7 @@ public class UserAchievementServiceImpl implements UserAchievementService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PagedResponseDto<UserAchievementResponseDto> getUserAchievements(Pageable pageable) {
         String deviceTag = userService.getCurrentDeviceTag();
         Page<Achievement> achievements = achievementRepository.findAll(pageable);

--- a/src/main/java/com/stempo/api/domain/application/service/UserService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserService.java
@@ -12,6 +12,8 @@ public interface UserService {
 
     User save(User user);
 
+    void delete(User user);
+
     String getCurrentDeviceTag();
 
     User getCurrentUser();

--- a/src/main/java/com/stempo/api/domain/application/service/UserServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UserServiceImpl.java
@@ -30,6 +30,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public void delete(User user) {
+        repository.delete(user);
+    }
+
+    @Override
     public String getCurrentDeviceTag() {
         return AuthUtil.getAuthenticationInfoDeviceTag();
     }

--- a/src/main/java/com/stempo/api/domain/application/service/VideoServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/VideoServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,24 +20,28 @@ public class VideoServiceImpl implements VideoService {
     private final VideoRepository repository;
 
     @Override
+    @Transactional
     public Long registerVideo(VideoRequestDto requestDto) {
         Video video = VideoRequestDto.toDomain(requestDto);
         return repository.save(video).getId();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PagedResponseDto<VideoResponseDto> getVideos(Pageable pageable) {
         Page<Video> videos = repository.findAll(pageable);
         return new PagedResponseDto<>(videos.map(VideoResponseDto::toDto));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public VideoDetailsResponseDto getVideo(Long videoId) {
         Video video = repository.findByIdOrThrow(videoId);
         return VideoDetailsResponseDto.toDto(video);
     }
 
     @Override
+    @Transactional
     public Long updateVideo(Long videoId, VideoUpdateRequestDto requestDto) {
         Video video = repository.findByIdOrThrow(videoId);
         video.update(requestDto);
@@ -44,6 +49,7 @@ public class VideoServiceImpl implements VideoService {
     }
 
     @Override
+    @Transactional
     public Long deleteVideo(Long id) {
         Video video = repository.findByIdOrThrow(id);
         video.delete();

--- a/src/main/java/com/stempo/api/domain/domain/repository/BoardRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/BoardRepository.java
@@ -5,11 +5,17 @@ import com.stempo.api.domain.domain.model.BoardCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface BoardRepository {
 
     Board save(Board board);
 
+    void deleteAll(List<Board> boards);
+
     Page<Board> findByCategory(BoardCategory category, Pageable pageable);
 
     Board findByIdOrThrow(Long boardId);
+
+    List<Board> findByDeviceTag(String deviceTag);
 }

--- a/src/main/java/com/stempo/api/domain/domain/repository/HomeworkRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/HomeworkRepository.java
@@ -4,13 +4,19 @@ import com.stempo.api.domain.domain.model.Homework;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface HomeworkRepository {
 
     Homework save(Homework homework);
+
+    void delete(Homework homework);
+
+    void deleteAll(List<Homework> homeworks);
 
     Page<Homework> findByCompleted(Boolean completed, Pageable pageable);
 
     Homework findByIdOrThrow(Long homeworkId);
 
-    void delete(Homework homework);
+    List<Homework> findByDeviceTag(String deviceTag);
 }

--- a/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
@@ -9,7 +9,11 @@ public interface RecordRepository {
 
     Record save(Record record);
 
+    void deleteAll(List<Record> records);
+
     List<Record> findByDateBetween(String deviceTag, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
     Record findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime);
+
+    List<Record> findByDeviceTag(String deviceTag);
 }

--- a/src/main/java/com/stempo/api/domain/domain/repository/UserRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository {
     User findByIdOrThrow(String deviceTag);
 
     boolean existsById(String id);
+
+    void delete(User user);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/BoardJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/BoardJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
@@ -22,4 +23,6 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
             "WHERE b.id = :boardId " +
             "AND b.deleted = false")
     Optional<BoardEntity> findByIdAndNotDeleted(Long boardId);
+
+    List<BoardEntity> findByDeviceTag(String deviceTag);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/BoardRepositoryImpl.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class BoardRepositoryImpl implements BoardRepository {
@@ -27,6 +29,14 @@ public class BoardRepositoryImpl implements BoardRepository {
     }
 
     @Override
+    public void deleteAll(List<Board> boards) {
+        List<BoardEntity> entities = boards.stream()
+                .map(mapper::toEntity)
+                .toList();
+        repository.deleteAll(entities);
+    }
+
+    @Override
     public Page<Board> findByCategory(BoardCategory category, Pageable pageable) {
         Page<BoardEntity> boards = repository.findByCategory(category, pageable);
         return boards.map(mapper::toDomain);
@@ -37,5 +47,13 @@ public class BoardRepositoryImpl implements BoardRepository {
         return repository.findByIdAndNotDeleted(boardId)
                 .map(mapper::toDomain)
                 .orElseThrow(() -> new NotFoundException("[Board] id: " + boardId + " not found"));
+    }
+
+    @Override
+    public List<Board> findByDeviceTag(String deviceTag) {
+        List<BoardEntity> entities = repository.findByDeviceTag(deviceTag);
+        return entities.stream()
+                .map(mapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/HomeworkJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/HomeworkJpaRepository.java
@@ -5,6 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface HomeworkJpaRepository extends JpaRepository<HomeworkEntity, Long> {
+
     Page<HomeworkEntity> findByCompleted(Boolean completed, Pageable pageable);
+
+    List<HomeworkEntity> findByDeviceTag(String deviceTag);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/HomeworkRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/HomeworkRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,6 +25,20 @@ public class HomeworkRepositoryImpl implements HomeworkRepository {
         HomeworkEntity entity = mapper.toEntity(homework);
         HomeworkEntity savedEntity = repository.save(entity);
         return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public void delete(Homework homework) {
+        HomeworkEntity entity = mapper.toEntity(homework);
+        repository.delete(entity);
+    }
+
+    @Override
+    public void deleteAll(List<Homework> homeworks) {
+        List<HomeworkEntity> entities = homeworks.stream()
+                .map(mapper::toEntity)
+                .toList();
+        repository.deleteAll(entities);
     }
 
     @Override
@@ -43,8 +58,10 @@ public class HomeworkRepositoryImpl implements HomeworkRepository {
     }
 
     @Override
-    public void delete(Homework homework) {
-        HomeworkEntity entity = mapper.toEntity(homework);
-        repository.delete(entity);
+    public List<Homework> findByDeviceTag(String deviceTag) {
+        List<HomeworkEntity> entities = repository.findByDeviceTag(deviceTag);
+        return entities.stream()
+                .map(mapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordJpaRepository.java
@@ -32,4 +32,6 @@ public interface RecordJpaRepository extends JpaRepository<RecordEntity, Long> {
             @Param("deviceTag") String deviceTag,
             @Param("startDateTime") LocalDateTime startDateTime
     );
+
+    List<RecordEntity> findByDeviceTag(String deviceTag);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
@@ -26,6 +26,14 @@ public class RecordRepositoryImpl implements RecordRepository {
     }
 
     @Override
+    public void deleteAll(List<Record> records) {
+        List<RecordEntity> jpaEntities = records.stream()
+                .map(mapper::toEntity)
+                .toList();
+        repository.deleteAll(jpaEntities);
+    }
+
+    @Override
     public List<Record> findByDateBetween(String deviceTag, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         List<RecordEntity> jpaEntities = repository.findByDateBetween(deviceTag, startDateTime, endDateTime);
         return jpaEntities.stream()
@@ -38,5 +46,13 @@ public class RecordRepositoryImpl implements RecordRepository {
         Optional<RecordEntity> jpaEntity = repository.findLatestBeforeStartDate(deviceTag, startDateTime);
         return jpaEntity.map(mapper::toDomain)
                 .orElse(null);
+    }
+
+    @Override
+    public List<Record> findByDeviceTag(String deviceTag) {
+        List<RecordEntity> jpaEntities = repository.findByDeviceTag(deviceTag);
+        return jpaEntities.stream()
+                .map(mapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UserRepositoryImpl.java
@@ -41,4 +41,10 @@ public class UserRepositoryImpl implements UserRepository {
     public boolean existsById(String id) {
         return repository.existsById(id);
     }
+
+    @Override
+    public void delete(User user) {
+        UserEntity jpaEntity = mapper.toEntity(user);
+        repository.delete(jpaEntity);
+    }
 }

--- a/src/main/java/com/stempo/api/domain/presentation/AuthController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/AuthController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +29,14 @@ public class AuthController {
     ) {
         TokenInfo token = authService.registerUser(requestDto);
         return ApiResponse.success(token);
+    }
+
+    @Operation(summary = "[U] 회원 탈퇴", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @DeleteMapping("/api/v1/auth/unregister")
+    public ApiResponse<String> unregisterUser() {
+        String deviceTag = authService.unregisterUser();
+        return ApiResponse.success(deviceTag);
     }
 
     @Operation(summary = "로그인", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +


### PR DESCRIPTION
## Summary

> #42

회원 탈퇴 API를 추가하고, 탈퇴 시 사용자의 재활 기록, 작성한 게시글, 과제 데이터를 같이 삭제하도록 합니다.

## Tasks

- 회원 탈퇴 API 구현
- 도메인 이벤트를 통해 관련 데이터(재활 기록, 작성한 게시글, 과제)를 삭제하도록 처리.