### PR TITLE
feat: 파일 관리 API 추가 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/handler/FileHandler.java
+++ b/src/main/java/com/stempo/api/domain/application/handler/FileHandler.java
@@ -1,6 +1,7 @@
 package com.stempo.api.domain.application.handler;
 
 import com.stempo.api.global.util.FileUtil;
+import com.stempo.api.global.util.LogSanitizerUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,5 +67,14 @@ public class FileHandler {
         Files.copy(file.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
         FileUtil.setFilePermissions(destination, savePath, filePath);
         return savePath;
+    }
+
+    public boolean deleteFile(String savedPath) {
+        File fileToDelete = new File(savedPath);
+        boolean deleted = fileToDelete.delete();
+        if (!deleted) {
+            log.error("Failed to delete file: {}", LogSanitizerUtil.sanitizeForLog(savedPath));
+        }
+        return deleted;
     }
 }

--- a/src/main/java/com/stempo/api/domain/application/service/FileService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/FileService.java
@@ -3,9 +3,14 @@ package com.stempo.api.domain.application.service;
 
 import com.stempo.api.domain.application.handler.FileHandler;
 import com.stempo.api.domain.domain.model.UploadedFile;
+import com.stempo.api.domain.presentation.dto.response.UploadedFileResponseDto;
+import com.stempo.api.global.dto.PagedResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -23,6 +28,7 @@ public class FileService {
     @Value("${resource.file.url}")
     private String fileURL;
 
+    @Transactional
     public List<String> saveFiles(List<MultipartFile> multipartFiles, String path) throws IOException {
         List<String> filePaths = new ArrayList<>();
         for (MultipartFile multipartFile : multipartFiles) {
@@ -30,6 +36,12 @@ public class FileService {
             filePaths.add(filePath);
         }
         return filePaths;
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponseDto<UploadedFileResponseDto> getFiles(Pageable pageable) {
+        Page<UploadedFile> uploadedFiles = uploadedFileService.getUploadedFiles(pageable);
+        return new PagedResponseDto<>(uploadedFiles.map(UploadedFileResponseDto::toDto));
     }
 
     public String saveFile(MultipartFile multipartFile, String path) throws IOException {

--- a/src/main/java/com/stempo/api/domain/application/service/FileService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/FileService.java
@@ -3,8 +3,11 @@ package com.stempo.api.domain.application.service;
 
 import com.stempo.api.domain.application.handler.FileHandler;
 import com.stempo.api.domain.domain.model.UploadedFile;
+import com.stempo.api.domain.presentation.dto.request.DeleteFileRequestDto;
 import com.stempo.api.domain.presentation.dto.response.UploadedFileResponseDto;
 import com.stempo.api.global.dto.PagedResponseDto;
+import com.stempo.api.global.exception.NotFoundException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -62,6 +65,24 @@ public class FileService {
         UploadedFile uploadedFile = UploadedFile.create(file.getName(), fileName, savedFilePath, url, file.length());
         uploadedFileService.saveUploadedFile(uploadedFile);
         return url;
+    }
+
+    public boolean deleteFile(@Valid DeleteFileRequestDto requestDto) {
+        String url = requestDto.getUrl();
+        UploadedFile uploadedFile = uploadedFileService.getUploadedFileByUrl(url);
+        String filePath = uploadedFile.getSavedPath();
+
+        File storedFile = new File(filePath);
+        if (!storedFile.exists()) {
+            throw new NotFoundException("File does not exist");
+        }
+
+        boolean deleted = fileHandler.deleteFile(uploadedFile.getSavedPath());
+        if (deleted) {
+            uploadedFileService.deleteUploadedFile(uploadedFile);
+        }
+
+        return deleted;
     }
 }
 

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileService.java
@@ -13,4 +13,8 @@ public interface UploadedFileService {
     Page<UploadedFile> getUploadedFiles(Pageable pageable);
 
     Optional<UploadedFile> getUploadedFileByOriginalFileName(String fileName);
+
+    UploadedFile getUploadedFileByUrl(String url);
+
+    void deleteUploadedFile(UploadedFile uploadedFile);
 }

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileService.java
@@ -1,12 +1,16 @@
 package com.stempo.api.domain.application.service;
 
 import com.stempo.api.domain.domain.model.UploadedFile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface UploadedFileService {
 
     UploadedFile saveUploadedFile(UploadedFile uploadedFile);
+
+    Page<UploadedFile> getUploadedFiles(Pageable pageable);
 
     Optional<UploadedFile> getUploadedFileByOriginalFileName(String fileName);
 }

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
@@ -32,4 +32,16 @@ public class UploadedFileServiceImpl implements UploadedFileService {
     public Optional<UploadedFile> getUploadedFileByOriginalFileName(String fileName) {
         return uploadedFileRepository.findByOriginalFileName(fileName);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UploadedFile getUploadedFileByUrl(String url) {
+        return uploadedFileRepository.findByUrlOrThrow(url);
+    }
+
+    @Override
+    @Transactional
+    public void deleteUploadedFile(UploadedFile uploadedFile) {
+        uploadedFileRepository.delete(uploadedFile);
+    }
 }

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
@@ -3,6 +3,8 @@ package com.stempo.api.domain.application.service;
 import com.stempo.api.domain.domain.model.UploadedFile;
 import com.stempo.api.domain.domain.repository.UploadedFileRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,11 @@ public class UploadedFileServiceImpl implements UploadedFileService {
     @Transactional
     public UploadedFile saveUploadedFile(UploadedFile uploadedFile) {
         return uploadedFileRepository.save(uploadedFile);
+    }
+
+    @Override
+    public Page<UploadedFile> getUploadedFiles(Pageable pageable) {
+        return uploadedFileRepository.findAll(pageable);
     }
 
     @Override

--- a/src/main/java/com/stempo/api/domain/domain/repository/UploadedFileRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/UploadedFileRepository.java
@@ -2,12 +2,16 @@ package com.stempo.api.domain.domain.repository;
 
 
 import com.stempo.api.domain.domain.model.UploadedFile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface UploadedFileRepository {
 
     UploadedFile save(UploadedFile uploadedFile);
+
+    Page<UploadedFile> findAll(Pageable pageable);
 
     Optional<UploadedFile> findByOriginalFileName(String outputFilename);
 }

--- a/src/main/java/com/stempo/api/domain/domain/repository/UploadedFileRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/UploadedFileRepository.java
@@ -14,4 +14,8 @@ public interface UploadedFileRepository {
     Page<UploadedFile> findAll(Pageable pageable);
 
     Optional<UploadedFile> findByOriginalFileName(String outputFilename);
+
+    UploadedFile findByUrlOrThrow(String url);
+
+    void delete(UploadedFile uploadedFile);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileJpaRepository.java
@@ -7,5 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UploadedFileJpaRepository extends JpaRepository<UploadedFileEntity, Long> {
+
     Optional<UploadedFileEntity> findByOriginalFileName(String fileName);
+
+    Optional<UploadedFileEntity> findByUrl(String url);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.stempo.api.domain.domain.model.UploadedFile;
 import com.stempo.api.domain.domain.repository.UploadedFileRepository;
 import com.stempo.api.domain.persistence.entity.UploadedFileEntity;
 import com.stempo.api.domain.persistence.mappper.UploadedFileMapper;
+import com.stempo.api.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,5 +36,18 @@ public class UploadedFileRepositoryImpl implements UploadedFileRepository {
     public Optional<UploadedFile> findByOriginalFileName(String fileName) {
         return repository.findByOriginalFileName(fileName)
                 .map(mapper::toDomain);
+    }
+
+    @Override
+    public UploadedFile findByUrlOrThrow(String url) {
+        return repository.findByUrl(url)
+                .map(mapper::toDomain)
+                .orElseThrow(() -> new NotFoundException("[UploadedFile] url: " + url + " not found"));
+    }
+
+    @Override
+    public void delete(UploadedFile uploadedFile) {
+        UploadedFileEntity jpaEntity = mapper.toEntity(uploadedFile);
+        repository.delete(jpaEntity);
     }
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.stempo.api.domain.domain.repository.UploadedFileRepository;
 import com.stempo.api.domain.persistence.entity.UploadedFileEntity;
 import com.stempo.api.domain.persistence.mappper.UploadedFileMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -21,6 +23,12 @@ public class UploadedFileRepositoryImpl implements UploadedFileRepository {
         UploadedFileEntity jpaEntity = mapper.toEntity(uploadedFile);
         UploadedFileEntity savedEntity = repository.save(jpaEntity);
         return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Page<UploadedFile> findAll(Pageable pageable) {
+        return repository.findAll(pageable)
+                .map(mapper::toDomain);
     }
 
     @Override

--- a/src/main/java/com/stempo/api/domain/presentation/FileController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/FileController.java
@@ -1,6 +1,7 @@
 package com.stempo.api.domain.presentation;
 
 import com.stempo.api.domain.application.service.FileService;
+import com.stempo.api.domain.presentation.dto.request.DeleteFileRequestDto;
 import com.stempo.api.domain.presentation.dto.response.UploadedFileResponseDto;
 import com.stempo.api.global.dto.ApiResponse;
 import com.stempo.api.global.dto.PagedResponseDto;
@@ -9,12 +10,15 @@ import com.stempo.api.global.exception.SortingArgumentException;
 import com.stempo.api.global.util.PageableUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,5 +57,16 @@ public class FileController {
         Pageable pageable = pageableUtil.createPageable(page, size, sortBy, sortDirection, UploadedFileResponseDto.class);
         PagedResponseDto<UploadedFileResponseDto> uploadedFiles = fileService.getFiles(pageable);
         return ApiResponse.success(uploadedFiles);
+    }
+
+    @Operation(summary = "[A] 파일 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
+            "파일 경로(/resources/files/)를 받아 해당 파일을 삭제함")
+    @Secured({ "ROLE_ADMIN" })
+    @DeleteMapping("/api/v1/files")
+    public ApiResponse<Boolean> deleteFile(
+            @Valid @RequestBody DeleteFileRequestDto requestDto
+    ) {
+        boolean deleted = fileService.deleteFile(requestDto);
+        return ApiResponse.success(deleted);
     }
 }

--- a/src/main/java/com/stempo/api/domain/presentation/FileController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/FileController.java
@@ -1,11 +1,19 @@
 package com.stempo.api.domain.presentation;
 
 import com.stempo.api.domain.application.service.FileService;
+import com.stempo.api.domain.presentation.dto.response.UploadedFileResponseDto;
 import com.stempo.api.global.dto.ApiResponse;
+import com.stempo.api.global.dto.PagedResponseDto;
+import com.stempo.api.global.exception.InvalidColumnException;
+import com.stempo.api.global.exception.SortingArgumentException;
+import com.stempo.api.global.util.PageableUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,13 +28,29 @@ import java.util.List;
 public class FileController {
 
     private final FileService fileService;
+    private final PageableUtil pageableUtil;
 
     @Operation(summary = "[U] 게시판 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping(value = "/api/v1/files/boards", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<String>> boardFileUpload(
             @RequestParam(name = "multipartFile", required = false) List<MultipartFile> multipartFiles
     ) throws IOException {
         List<String> filePaths = fileService.saveFiles(multipartFiles, "boards");
         return ApiResponse.success(filePaths);
+    }
+
+    @Operation(summary = "[A] 파일 목록 조회", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @Secured({ "ROLE_ADMIN" })
+    @GetMapping("/api/v1/files")
+    public ApiResponse<PagedResponseDto<UploadedFileResponseDto>> getFiles(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "sortBy", defaultValue = "createdAt") List<String> sortBy,
+            @RequestParam(name = "sortDirection", defaultValue = "desc") List<String> sortDirection
+    ) throws InvalidColumnException, SortingArgumentException {
+        Pageable pageable = pageableUtil.createPageable(page, size, sortBy, sortDirection, UploadedFileResponseDto.class);
+        PagedResponseDto<UploadedFileResponseDto> uploadedFiles = fileService.getFiles(pageable);
+        return ApiResponse.success(uploadedFiles);
     }
 }

--- a/src/main/java/com/stempo/api/domain/presentation/FileController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/FileController.java
@@ -40,7 +40,8 @@ public class FileController {
         return ApiResponse.success(filePaths);
     }
 
-    @Operation(summary = "[A] 파일 목록 조회", description = "ROLE_ADMIN 이상의 권한이 필요함")
+    @Operation(summary = "[A] 파일 목록 조회", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
+            "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
     @Secured({ "ROLE_ADMIN" })
     @GetMapping("/api/v1/files")
     public ApiResponse<PagedResponseDto<UploadedFileResponseDto>> getFiles(

--- a/src/main/java/com/stempo/api/domain/presentation/HomeworkController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/HomeworkController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -34,6 +35,7 @@ public class HomeworkController {
     private final PageableUtil pageableUtil;
 
     @Operation(summary = "[U] 과제 추가", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping(value = "/api/v1/homeworks")
     public ApiResponse<Long> addHomework(
             @Valid @RequestBody HomeworkRequestDto requestDto
@@ -46,6 +48,7 @@ public class HomeworkController {
             "completed(Optional)가 true이면 완료된 과제, false이면 미완료된 과제를 조회함<br>" +
             "completed가 없으면 모든 과제를 조회함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @GetMapping(value = "/api/v1/homeworks")
     public ApiResponse<PagedResponseDto<HomeworkResponseDto>> getHomeworks(
             @RequestParam(name = "completed", required = false) Boolean completed,
@@ -60,6 +63,7 @@ public class HomeworkController {
     }
 
     @Operation(summary = "[U] 과제 수정", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PatchMapping(value = "/api/v1/homeworks/{homeworkId}")
     public ApiResponse<Long> updateHomework(
             @PathVariable(name = "homeworkId") Long homeworkId,
@@ -70,6 +74,7 @@ public class HomeworkController {
     }
 
     @Operation(summary = "[U] 과제 삭제", description = "ROLE_USER 이상의 권한이 필요함")
+    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @DeleteMapping(value = "/api/v1/homeworks/{homeworkId}")
     public ApiResponse<Long> deleteHomework(
             @PathVariable(name = "homeworkId") Long homeworkId

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/DeleteFileRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/DeleteFileRequestDto.java
@@ -1,0 +1,15 @@
+package com.stempo.api.domain.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DeleteFileRequestDto {
+
+    @NotBlank(message = "File URL is required")
+    @Schema(description = "파일경로", example = "/resources/files/boards/123456.png", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String url;
+}

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/UploadedFileResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/UploadedFileResponseDto.java
@@ -12,15 +12,31 @@ public class UploadedFileResponseDto {
 
     private String originalFileName;
     private String url;
-    private Long fileSize;
+    private String fileSize;
     private LocalDateTime createdAt;
 
     public static UploadedFileResponseDto toDto(UploadedFile uploadedFile) {
         return UploadedFileResponseDto.builder()
                 .originalFileName(uploadedFile.getOriginalFileName())
                 .url(uploadedFile.getUrl())
-                .fileSize(uploadedFile.getFileSize())
+                .fileSize(formatFileSize(uploadedFile.getFileSize()))
                 .createdAt(uploadedFile.getCreatedAt())
                 .build();
+    }
+
+    private static String formatFileSize(long fileSize) {
+        final long KB = 1024;
+        final long MB = KB * 1024;
+        final long GB = MB * 1024;
+
+        if (fileSize < KB) {
+            return fileSize + " B";
+        } else if (fileSize < MB) {
+            return String.format("%.2fKB", fileSize / (double) KB);
+        } else if (fileSize < GB) {
+            return String.format("%.2fMB", fileSize / (double) MB);
+        } else {
+            return String.format("%.2fGB", fileSize / (double) GB);
+        }
     }
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/UploadedFileResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/UploadedFileResponseDto.java
@@ -1,0 +1,26 @@
+package com.stempo.api.domain.presentation.dto.response;
+
+import com.stempo.api.domain.domain.model.UploadedFile;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UploadedFileResponseDto {
+
+    private String originalFileName;
+    private String url;
+    private Long fileSize;
+    private LocalDateTime createdAt;
+
+    public static UploadedFileResponseDto toDto(UploadedFile uploadedFile) {
+        return UploadedFileResponseDto.builder()
+                .originalFileName(uploadedFile.getOriginalFileName())
+                .url(uploadedFile.getUrl())
+                .fileSize(uploadedFile.getFileSize())
+                .createdAt(uploadedFile.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

> #52 

파일 업로드 후 서버에 저장된 파일을 조회하고, 필요 시 삭제할 수 있는 API 기능을 추가했습니다. 이를 통해 관리자가 업로드된 파일을 확인하고 관리할 수 있는 기능을 제공합니다.

## Tasks

- **파일 조회 API 추가**
    - 서버에 업로드된 파일의 리스트를 조회할 수 있는 API를 구현했습니다.
    - 응답에는 파일의 메타 정보(파일명, 파일 크기, 업로드 날짜 등)를 포함하여 사용자가 파일의 상태를 쉽게 파악할 수 있도록 했습니다.

- **파일 삭제 API 추가**
    - 업로드된 파일을 삭제할 수 있는 API를 구현했습니다.
    - 삭제 요청 시, 해당 파일이 존재하는지 확인한 후, 파일과 관련된 메타 데이터를 안전하게 삭제하는 로직을 추가했습니다.
    - 파일이 존재하지 않을 경우 적절한 예외 처리를 통해 오류 메시지를 반환하도록 설계했습니다.