### PR TITLE
refactor: deviceTag 암호화를 위한 고유 암호화 값 추가 및 IV 생성 방식 개선 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/AuthServiceImpl.java
@@ -7,6 +7,7 @@ import com.stempo.api.domain.presentation.dto.request.AuthRequestDto;
 import com.stempo.api.domain.presentation.dto.response.TokenInfo;
 import com.stempo.api.global.auth.exception.TokenForgeryException;
 import com.stempo.api.global.auth.jwt.JwtTokenProvider;
+import com.stempo.api.global.config.AesConfig;
 import com.stempo.api.global.config.CustomAuthenticationProvider;
 import com.stempo.api.global.util.EncryptionUtil;
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,6 +32,7 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final EncryptionUtil encryptionUtil;
     private final ApplicationEventPublisher eventPublisher;
+    private final AesConfig aesConfig;
 
     @Override
     @Transactional
@@ -76,7 +78,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private String encryptDeviceTag(String deviceTag) {
-        return encryptionUtil.encryptWithHashedIV(deviceTag, deviceTag);
+        return encryptionUtil.encryptWithHashedIV(deviceTag, aesConfig.getDeviceTagSecretKey());
     }
 
     private String encryptPassword(String password) {

--- a/src/main/java/com/stempo/api/global/config/AesConfig.java
+++ b/src/main/java/com/stempo/api/global/config/AesConfig.java
@@ -10,14 +10,17 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 public class AesConfig {
 
-    @Value("${security.aes-key}")
+    @Value("${security.aes.key}")
     private String secretKey;
 
-    @Value("${security.iv-length-bytes}")
+    @Value("${security.aes.iv-length-bytes}")
     private int ivLengthBytes;
 
-    @Value("${security.gcm-tag-length-bits}")
+    @Value("${security.aes.gcm-tag-length-bits}")
     private int gcmTagLengthBits;
+
+    @Value("${security.aes.device-tag-secret-key}")
+    private String deviceTagSecretKey;
 
     @Bean
     public EncryptionUtil encryptionUtil(AesConfig aesConfig) {


### PR DESCRIPTION
## Summary

> #56 

기존에는 `deviceTag`의 고유 해시 값을 사용하여 IV를 생성하고 있었으나, 퍼블릭 프로젝트에서 직접적으로 `deviceTag` 값을 활용하는 것은 보안상 취약점이 될 수 있습니다. 이에 `deviceTag` 전용으로 사용할 고유한 암호화 값을 추가하여, IV를 생성할 때 더 안전하게 암호화 절차를 처리하도록 개선했습니다. 이 작업을 통해 암호화 보안을 더욱 강화하고, 퍼블릭 프로젝트에서도 안전하게 데이터를 처리할 수 있도록 했습니다.

## Tasks

- **고유한 암호화 값 추가**
    - `application.yml` 파일에 `deviceTag` 전용 암호화 값을 `deviceTagSecretKey`로 추가.
    - IV 생성 시 `deviceTag` 자체 대신, 새로 추가된 `deviceTagSecretKey` 값을 사용하여 IV를 생성하도록 변경.

- **IV 생성 방식 개선**
    - `EncryptionUtil`에서 IV 생성 시 `deviceTagSecretKey`를 기반으로 하여 고유한 IV를 생성.
    - `AuthServiceImpl`의 deviceTag 암호화 로직에서 기존 `deviceTag`가 아닌, `deviceTagSecretKey`를 사용하도록 수정.