### PR TITLE
refactor: 보행 훈련 기록에서 조회 기준 날짜 이전의 데이터가 없을 경우 정확도를 0으로 반환하도록 수정 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/RecordRepository.java
@@ -4,6 +4,7 @@ import com.stempo.api.domain.domain.model.Record;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface RecordRepository {
 
@@ -13,7 +14,7 @@ public interface RecordRepository {
 
     List<Record> findByDateBetween(String deviceTag, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
-    Record findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime);
+    Optional<Record> findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime);
 
     List<Record> findByDeviceTag(String deviceTag);
 

--- a/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/RecordRepositoryImpl.java
@@ -42,10 +42,9 @@ public class RecordRepositoryImpl implements RecordRepository {
     }
 
     @Override
-    public Record findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime) {
-        Optional<RecordEntity> jpaEntity = repository.findLatestBeforeStartDate(deviceTag, startDateTime);
-        return jpaEntity.map(mapper::toDomain)
-                .orElse(null);
+    public Optional<Record> findLatestBeforeStartDate(String deviceTag, LocalDateTime startDateTime) {
+        return repository.findLatestBeforeStartDate(deviceTag, startDateTime)
+                .map(mapper::toDomain);
     }
 
     @Override

--- a/src/main/java/com/stempo/api/domain/presentation/RecordController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RecordController.java
@@ -39,7 +39,7 @@ public class RecordController {
     @Operation(summary = "[U] 내 보행 훈련 기록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "startDate와 endDate는 yyyy-MM-dd 형식으로 입력해야 함<br>" +
             "startDate 이전의 가장 최신 데이터와 startDate부터 endDate까지의 데이터를 가져옴<br>" +
-            "데이터가 없을 경우 오늘 날짜로 값을 0으로 설정하여 반환")
+            "데이터가 없을 경우 startDate 이전 날짜, 정확도 0으로 설정하여 반환")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @GetMapping("/api/v1/records")
     public ApiResponse<List<RecordResponseDto>> getRecords(

--- a/src/main/java/com/stempo/api/domain/presentation/RecordController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/RecordController.java
@@ -21,12 +21,12 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Record", description = "기록")
+@Tag(name = "Record", description = "보행 훈련 기록")
 public class RecordController {
 
     private final RecordService recordService;
 
-    @Operation(summary = "[U] 재활 운동 기록", description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 보행 훈련 기록", description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/records")
     public ApiResponse<String> record(
@@ -36,7 +36,7 @@ public class RecordController {
         return ApiResponse.success(deviceTag);
     }
 
-    @Operation(summary = "[U] 내 재활 운동 기록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
+    @Operation(summary = "[U] 내 보행 훈련 기록 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "startDate와 endDate는 yyyy-MM-dd 형식으로 입력해야 함<br>" +
             "startDate 이전의 가장 최신 데이터와 startDate부터 endDate까지의 데이터를 가져옴<br>" +
             "데이터가 없을 경우 오늘 날짜로 값을 0으로 설정하여 반환")
@@ -50,7 +50,7 @@ public class RecordController {
         return ApiResponse.success(records);
     }
 
-    @Operation(summary = "[U] 내 재활 운동 기록 통계" , description = "ROLE_USER 이상의 권한이 필요함")
+    @Operation(summary = "[U] 내 보행 훈련 기록 통계" , description = "ROLE_USER 이상의 권한이 필요함")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @GetMapping("/api/v1/records/statistics")
     public ApiResponse<RecordStatisticsResponseDto> getRecordStatistics() {

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordResponseDto.java
@@ -14,20 +14,11 @@ public class RecordResponseDto {
     private Integer steps;
     private LocalDate date;
 
-    public static RecordResponseDto createDefault() {
+    public static RecordResponseDto create(Double accuracy, Integer duration, Integer steps, LocalDate date) {
         return RecordResponseDto.builder()
-                .accuracy(0.0)
-                .duration(0)
-                .steps(0)
-                .date(LocalDate.now())
-                .build();
-    }
-
-    public static RecordResponseDto create(String accuracy, String duration, String steps, LocalDate date) {
-        return RecordResponseDto.builder()
-                .accuracy(Double.parseDouble(accuracy))
-                .duration(Integer.parseInt(duration))
-                .steps(Integer.parseInt(steps))
+                .accuracy(accuracy)
+                .duration(duration)
+                .steps(steps)
                 .date(date)
                 .build();
     }


### PR DESCRIPTION
## Summary

> #58 

내 재활 운동 기록 조회 API 에서 `startDateTime` 이전에 가장 최신 데이터가 없는 경우, 정확도(accuracy)를 0으로 설정하여 기본값을 반환하는 로직을 추가했습니다. 이로 인해, 기록이 존재하지 않을 경우에도 적절한 기본값을 제공하여 UI에 빈 데이터가 노출되지 않도록 보완했습니다.

## Tasks

- `startDateTime` 이전 데이터가 없을 시 `startDateTime` 기준 하루 전 날짜로 정확도 `0`, 시간 `0`, 걸음 수 `0`의 기본값을 반환하도록 변경
