### PR TITLE
refactor: 게시글 작성 시 fileUrls의 리소스 존재 여부를 검증하는 로직 추가 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/application/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/stempo/api/domain/application/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.stempo.api.domain.application.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/stempo/api/domain/application/service/BoardServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/BoardServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardServiceImpl implements BoardService {
 
     private final UserService userService;
+    private final UploadedFileService uploadedFileService;
     private final BoardRepository repository;
     private final BoardDtoMapper mapper;
 
@@ -28,6 +29,7 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public Long registerBoard(BoardRequestDto requestDto) {
         User user = userService.getCurrentUser();
+        uploadedFileService.verifyFilesExist(requestDto.getFileUrls());
         Board board = mapper.toDomain(requestDto, user.getDeviceTag());
         board.validateAccessPermissionForNotice(user);
         return repository.save(board).getId();
@@ -46,6 +48,7 @@ public class BoardServiceImpl implements BoardService {
     public Long updateBoard(Long boardId, BoardUpdateRequestDto requestDto) {
         User user = userService.getCurrentUser();
         Board board = repository.findByIdOrThrow(boardId);
+        uploadedFileService.verifyFilesExist(requestDto.getFileUrls());
         board.validateAccessPermission(user);
         board.update(requestDto);
         return repository.save(board).getId();

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileService.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileService.java
@@ -4,6 +4,7 @@ import com.stempo.api.domain.domain.model.UploadedFile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UploadedFileService {
@@ -17,4 +18,6 @@ public interface UploadedFileService {
     UploadedFile getUploadedFileByUrl(String url);
 
     void deleteUploadedFile(UploadedFile uploadedFile);
+
+    void verifyFilesExist(List<String> fileUrls);
 }

--- a/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
+++ b/src/main/java/com/stempo/api/domain/application/service/UploadedFileServiceImpl.java
@@ -1,5 +1,6 @@
 package com.stempo.api.domain.application.service;
 
+import com.stempo.api.domain.application.exception.ResourceNotFoundException;
 import com.stempo.api.domain.domain.model.UploadedFile;
 import com.stempo.api.domain.domain.repository.UploadedFileRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -43,5 +45,17 @@ public class UploadedFileServiceImpl implements UploadedFileService {
     @Transactional
     public void deleteUploadedFile(UploadedFile uploadedFile) {
         uploadedFileRepository.delete(uploadedFile);
+    }
+
+    @Override
+    public void verifyFilesExist(List<String> fileUrls) {
+        if (fileUrls == null || fileUrls.isEmpty()) {
+            return;
+        }
+
+        long existingFileCount = uploadedFileRepository.countByUrlIn(fileUrls);
+        if (existingFileCount != fileUrls.size()) {
+            throw new ResourceNotFoundException("One or more files do not exist on the server.");
+        }
     }
 }

--- a/src/main/java/com/stempo/api/domain/domain/repository/UploadedFileRepository.java
+++ b/src/main/java/com/stempo/api/domain/domain/repository/UploadedFileRepository.java
@@ -5,6 +5,7 @@ import com.stempo.api.domain.domain.model.UploadedFile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UploadedFileRepository {
@@ -18,4 +19,6 @@ public interface UploadedFileRepository {
     UploadedFile findByUrlOrThrow(String url);
 
     void delete(UploadedFile uploadedFile);
+
+    long countByUrlIn(List<String> fileUrls);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/mappper/BoardMapper.java
+++ b/src/main/java/com/stempo/api/domain/persistence/mappper/BoardMapper.java
@@ -4,6 +4,8 @@ import com.stempo.api.domain.domain.model.Board;
 import com.stempo.api.domain.persistence.entity.BoardEntity;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+
 @Component
 public class BoardMapper {
 
@@ -14,7 +16,7 @@ public class BoardMapper {
                 .category(board.getCategory())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .fileUrls(board.getFileUrls())
+                .fileUrls(board.getFileUrls() == null ? new ArrayList<>() : board.getFileUrls())
                 .build();
     }
 
@@ -25,7 +27,7 @@ public class BoardMapper {
                 .category(entity.getCategory())
                 .title(entity.getTitle())
                 .content(entity.getContent())
-                .fileUrls(entity.getFileUrls())
+                .fileUrls(entity.getFileUrls() == null ? new ArrayList<>() : entity.getFileUrls())
                 .createdAt(entity.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileJpaRepository.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileJpaRepository.java
@@ -4,6 +4,7 @@ package com.stempo.api.domain.persistence.repository;
 import com.stempo.api.domain.persistence.entity.UploadedFileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UploadedFileJpaRepository extends JpaRepository<UploadedFileEntity, Long> {
@@ -11,4 +12,6 @@ public interface UploadedFileJpaRepository extends JpaRepository<UploadedFileEnt
     Optional<UploadedFileEntity> findByOriginalFileName(String fileName);
 
     Optional<UploadedFileEntity> findByUrl(String url);
+
+    long countByUrlIn(List<String> fileUrls);
 }

--- a/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
+++ b/src/main/java/com/stempo/api/domain/persistence/repository/UploadedFileRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -49,5 +50,10 @@ public class UploadedFileRepositoryImpl implements UploadedFileRepository {
     public void delete(UploadedFile uploadedFile) {
         UploadedFileEntity jpaEntity = mapper.toEntity(uploadedFile);
         repository.delete(jpaEntity);
+    }
+
+    @Override
+    public long countByUrlIn(List<String> fileUrls) {
+        return repository.countByUrlIn(fileUrls);
     }
 }

--- a/src/main/java/com/stempo/api/domain/presentation/mapper/BoardDtoMapper.java
+++ b/src/main/java/com/stempo/api/domain/presentation/mapper/BoardDtoMapper.java
@@ -5,6 +5,8 @@ import com.stempo.api.domain.presentation.dto.request.BoardRequestDto;
 import com.stempo.api.domain.presentation.dto.response.BoardResponseDto;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+
 @Component
 public class BoardDtoMapper {
 
@@ -14,7 +16,7 @@ public class BoardDtoMapper {
                 .category(requestDto.getCategory())
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
-                .fileUrls(requestDto.getFileUrls())
+                .fileUrls(requestDto.getFileUrls() == null ? new ArrayList<>() : requestDto.getFileUrls())
                 .build();
     }
 
@@ -25,7 +27,7 @@ public class BoardDtoMapper {
                 .category(board.getCategory())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .fileUrls(board.getFileUrls())
+                .fileUrls(board.getFileUrls() == null ? new ArrayList<>() : board.getFileUrls())
                 .createdAt(board.getCreatedAt().toString())
                 .build();
     }

--- a/src/main/java/com/stempo/api/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stempo/api/global/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.stempo.api.domain.application.exception.DirectoryCreationException;
 import com.stempo.api.domain.application.exception.FilePermissionException;
 import com.stempo.api.domain.application.exception.FileUploadFailException;
 import com.stempo.api.domain.application.exception.InvalidFileAttributeException;
+import com.stempo.api.domain.application.exception.ResourceNotFoundException;
 import com.stempo.api.domain.application.exception.RhythmGenerationException;
 import com.stempo.api.domain.application.exception.UserAlreadyExistsException;
 import com.stempo.api.global.auth.exception.AuthenticationInfoNotFoundException;
@@ -100,6 +101,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             NullPointerException.class,
             NotFoundException.class,
+            ResourceNotFoundException.class,
             NoSuchElementException.class,
             FileNotFoundException.class
     })


### PR DESCRIPTION
## Summary

> #62 

게시글 작성 시 `fileUrls`에 입력된 파일이 실제 서버에 존재하는지 검증하는 로직을 추가했습니다.

## Tasks

- fileUrls에 포함된 각 파일 URL이 실제 서버에 존재하는지 확인하는 검증 로직 구현
- 서버에 파일이 존재하지 않는 경우 예외 처리 추가
- 게시글 작성 로직에 파일 검증 로직 연동
