### PR TITLE
feat: Springdoc을 이용한 응답 예제값 설정 및 문서화 추가 완료

### DIFF
--- a/src/main/java/com/stempo/api/domain/presentation/controller/AuthController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.stempo.api.domain.presentation.controller;
 import com.stempo.api.domain.application.service.AuthService;
 import com.stempo.api.domain.presentation.dto.request.AuthRequestDto;
 import com.stempo.api.domain.presentation.dto.response.TokenInfo;
+import com.stempo.api.global.annotation.SuccessApiResponse;
 import com.stempo.api.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +33,7 @@ public class AuthController {
     }
 
     @Operation(summary = "[U] 회원 탈퇴", description = "ROLE_USER 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "deviceTag", dataType = String.class, dataDescription = "사용자의 디바이스 식별자")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @DeleteMapping("/api/v1/auth/unregister")
     public ApiResponse<String> unregisterUser() {

--- a/src/main/java/com/stempo/api/domain/presentation/controller/BoardController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.stempo.api.domain.domain.model.BoardCategory;
 import com.stempo.api.domain.presentation.dto.request.BoardRequestDto;
 import com.stempo.api.domain.presentation.dto.request.BoardUpdateRequestDto;
 import com.stempo.api.domain.presentation.dto.response.BoardResponseDto;
+import com.stempo.api.global.annotation.SuccessApiResponse;
 import com.stempo.api.global.dto.ApiResponse;
 import com.stempo.api.global.dto.PagedResponseDto;
 import com.stempo.api.global.exception.InvalidColumnException;
@@ -37,6 +38,7 @@ public class BoardController {
 
     @Operation(summary = "[U] 게시글 작성", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "공지사항은 ROLE_ADMIN 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "boardId", dataType = Long.class, dataDescription = "게시글 ID")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/boards")
     public ApiResponse<Long> registerBoard(
@@ -65,6 +67,7 @@ public class BoardController {
     
     @Operation(summary = "[U] 게시글 수정", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "ADMIN은 모든 게시글 수정 가능")
+    @SuccessApiResponse(data = "boardId", dataType = Long.class, dataDescription = "게시글 ID")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PatchMapping("/api/v1/boards/{boardId}")
     public ApiResponse<Long> updateBoard(
@@ -77,6 +80,7 @@ public class BoardController {
 
     @Operation(summary = "[U] 게시글 삭제", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "ADMIN은 모든 게시글 삭제 가능")
+    @SuccessApiResponse(data = "boardId", dataType = Long.class, dataDescription = "게시글 ID")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @DeleteMapping("/api/v1/boards/{boardId}")
     public ApiResponse<Long> deleteBoard(

--- a/src/main/java/com/stempo/api/domain/presentation/controller/FileController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/controller/FileController.java
@@ -3,6 +3,7 @@ package com.stempo.api.domain.presentation.controller;
 import com.stempo.api.domain.application.service.FileService;
 import com.stempo.api.domain.presentation.dto.request.DeleteFileRequestDto;
 import com.stempo.api.domain.presentation.dto.response.UploadedFileResponseDto;
+import com.stempo.api.global.annotation.SuccessApiResponse;
 import com.stempo.api.global.dto.ApiResponse;
 import com.stempo.api.global.dto.PagedResponseDto;
 import com.stempo.api.global.exception.InvalidColumnException;
@@ -35,6 +36,7 @@ public class FileController {
     private final PageableUtil pageableUtil;
 
     @Operation(summary = "[U] 게시판 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "[\"filePath1\", \"filePath2\"]", dataType = List.class, dataDescription = "파일 경로 리스트")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping(value = "/api/v1/files/boards", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<String>> boardFileUpload(
@@ -61,6 +63,7 @@ public class FileController {
 
     @Operation(summary = "[A] 파일 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "파일 경로(/resources/files/)를 받아 해당 파일을 삭제함")
+    @SuccessApiResponse(data = "true", dataType = Boolean.class, dataDescription = "파일 삭제 여부")
     @Secured({ "ROLE_ADMIN" })
     @DeleteMapping("/api/v1/files")
     public ApiResponse<Boolean> deleteFile(

--- a/src/main/java/com/stempo/api/domain/presentation/controller/HomeworkController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/controller/HomeworkController.java
@@ -4,6 +4,7 @@ import com.stempo.api.domain.application.service.HomeworkService;
 import com.stempo.api.domain.presentation.dto.request.HomeworkRequestDto;
 import com.stempo.api.domain.presentation.dto.request.HomeworkUpdateRequestDto;
 import com.stempo.api.domain.presentation.dto.response.HomeworkResponseDto;
+import com.stempo.api.global.annotation.SuccessApiResponse;
 import com.stempo.api.global.dto.ApiResponse;
 import com.stempo.api.global.dto.PagedResponseDto;
 import com.stempo.api.global.exception.InvalidColumnException;
@@ -35,6 +36,7 @@ public class HomeworkController {
     private final PageableUtil pageableUtil;
 
     @Operation(summary = "[U] 과제 추가", description = "ROLE_USER 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "homeworkId", dataType = Long.class, dataDescription = "과제 ID")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping(value = "/api/v1/homeworks")
     public ApiResponse<Long> addHomework(
@@ -63,6 +65,7 @@ public class HomeworkController {
     }
 
     @Operation(summary = "[U] 과제 수정", description = "ROLE_USER 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "homeworkId", dataType = Long.class, dataDescription = "과제 ID")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PatchMapping(value = "/api/v1/homeworks/{homeworkId}")
     public ApiResponse<Long> updateHomework(
@@ -74,6 +77,7 @@ public class HomeworkController {
     }
 
     @Operation(summary = "[U] 과제 삭제", description = "ROLE_USER 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "homeworkId", dataType = Long.class, dataDescription = "과제 ID")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @DeleteMapping(value = "/api/v1/homeworks/{homeworkId}")
     public ApiResponse<Long> deleteHomework(

--- a/src/main/java/com/stempo/api/domain/presentation/controller/RecordController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/controller/RecordController.java
@@ -4,6 +4,7 @@ import com.stempo.api.domain.application.service.RecordService;
 import com.stempo.api.domain.presentation.dto.request.RecordRequestDto;
 import com.stempo.api.domain.presentation.dto.response.RecordResponseDto;
 import com.stempo.api.domain.presentation.dto.response.RecordStatisticsResponseDto;
+import com.stempo.api.global.annotation.SuccessApiResponse;
 import com.stempo.api.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,6 +28,7 @@ public class RecordController {
     private final RecordService recordService;
 
     @Operation(summary = "[U] 보행 훈련 기록", description = "ROLE_USER 이상의 권한이 필요함")
+    @SuccessApiResponse(data = "deviceTag", dataType = String.class, dataDescription = "사용자의 디바이스 식별자")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/records")
     public ApiResponse<String> record(

--- a/src/main/java/com/stempo/api/domain/presentation/controller/RhythmController.java
+++ b/src/main/java/com/stempo/api/domain/presentation/controller/RhythmController.java
@@ -2,6 +2,7 @@ package com.stempo.api.domain.presentation.controller;
 
 import com.stempo.api.domain.application.service.RhythmService;
 import com.stempo.api.domain.presentation.dto.request.RhythmRequestDto;
+import com.stempo.api.global.annotation.SuccessApiResponse;
 import com.stempo.api.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,6 +23,7 @@ public class RhythmController {
     @Operation(summary = "[U] 리듬 생성", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "BPM은 10 이상 200 이하의 값이어야 함<br>" +
             "Bit는 1 이상 8 이하의 값이어야 함")
+    @SuccessApiResponse(data = "/resources/files/{fileName}", dataType = String.class, dataDescription = "파일 경로")
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     @PostMapping("/api/v1/rhythm")
     public ApiResponse<String> generateRhythm(

--- a/src/main/java/com/stempo/api/domain/presentation/dto/request/DeleteFileRequestDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/request/DeleteFileRequestDto.java
@@ -10,6 +10,6 @@ import lombok.Setter;
 public class DeleteFileRequestDto {
 
     @NotBlank(message = "File URL is required")
-    @Schema(description = "파일경로", example = "/resources/files/boards/123456.png", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "파일경로", example = "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.jpg", requiredMode = Schema.RequiredMode.REQUIRED)
     private String url;
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/BoardResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/BoardResponseDto.java
@@ -1,6 +1,7 @@
 package com.stempo.api.domain.presentation.dto.response;
 
 import com.stempo.api.domain.domain.model.BoardCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,11 +11,29 @@ import java.util.List;
 @Builder
 public class BoardResponseDto {
 
+    @Schema(description = "게시글 ID", example = "1")
     private Long id;
+
+    @Schema(description = "디바이스 식별자", example = "490154203237518")
     private String deviceTag;
+
+    @Schema(description = "카테고리", example = "NOTICE")
     private BoardCategory category;
+
+    @Schema(description = "제목", example = "청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo.")
     private String title;
+
+    @Schema(description = "내용", example = "Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다.")
     private String content;
+
+    @Schema(description = "파일 링크(JSON Array)", example = """
+    [
+        "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav",
+        "/resources/files/boards/1/1030487120626166_1dec3611-c148-4139-bb16-3d2a89ac1dd7.pdf"
+    ]
+    """)
     private List<String> fileUrls;
+
+    @Schema(description = "생성일시", example = "2024-01-01T00:00:00")
     private String createdAt;
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/HomeworkResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/HomeworkResponseDto.java
@@ -1,5 +1,6 @@
 package com.stempo.api.domain.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,7 +8,12 @@ import lombok.Getter;
 @Builder
 public class HomeworkResponseDto {
 
+    @Schema(description = "과제 ID", example = "1")
     private Long id;
+
+    @Schema(description = "과제 내용", example = "매일 스트레칭 운동 진행")
     private String description;
+
+    @Schema(description = "완료 여부", example = "false")
     private boolean completed;
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordResponseDto.java
@@ -1,5 +1,6 @@
 package com.stempo.api.domain.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,8 +10,15 @@ import java.time.LocalDate;
 @Builder
 public class RecordResponseDto {
 
+    @Schema(description = "정확도", example = "0.0")
     private Double accuracy;
+
+    @Schema(description = "재활 운동 시간(초)", example = "0")
     private Integer duration;
+
+    @Schema(description = "걸음 수", example = "0")
     private Integer steps;
+
+    @Schema(description = "날짜", example = "2024-01-01")
     private LocalDate date;
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordStatisticsResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/RecordStatisticsResponseDto.java
@@ -1,5 +1,6 @@
 package com.stempo.api.domain.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,7 +8,12 @@ import lombok.Getter;
 @Builder
 public class RecordStatisticsResponseDto {
 
+    @Schema(description = "오늘 보행 훈련 횟수", example = "0")
     private int todayWalkTrainingCount;
+
+    @Schema(description = "이번 주 보행 훈련 횟수", example = "0")
     private int weeklyWalkTrainingCount;
+
+    @Schema(description = "연속 보행 훈련 일수", example = "0")
     private int consecutiveWalkTrainingDays;
 }

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/TokenInfo.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/TokenInfo.java
@@ -1,5 +1,6 @@
 package com.stempo.api.domain.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TokenInfo {
 
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdGVtcG8iLCJpYXQiOjE2MzIwNjQwMzMsImV4cCI6MTYzMjA2NzYzM30.1")
     private String accessToken;
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdGVtcG8iLCJpYXQiOjE2MzIwNjQwMzMsImV4cCI6MTYzMjA2NzYzM30.1")
     private String refreshToken;
 
     public static TokenInfo create(String accessToken, String refreshToken) {

--- a/src/main/java/com/stempo/api/domain/presentation/dto/response/UploadedFileResponseDto.java
+++ b/src/main/java/com/stempo/api/domain/presentation/dto/response/UploadedFileResponseDto.java
@@ -1,5 +1,6 @@
 package com.stempo.api.domain.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,8 +10,15 @@ import java.time.LocalDateTime;
 @Builder
 public class UploadedFileResponseDto {
 
+    @Schema(description = "파일 원본 이름", example = "image.jpg")
     private String originalFileName;
+
+    @Schema(description = "파일 접근 URL", example = "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.jpg")
     private String url;
+
+    @Schema(description = "파일 크기", example = "1.0MB")
     private String fileSize;
+
+    @Schema(description = "파일 업로드 일시", example = "2024-01-01T00:00:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/stempo/api/global/annotation/SuccessApiResponse.java
+++ b/src/main/java/com/stempo/api/global/annotation/SuccessApiResponse.java
@@ -1,0 +1,15 @@
+package com.stempo.api.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SuccessApiResponse {
+    String description() default "OK";
+    String data() default "";
+    Class<?> dataType() default Void.class;
+    String dataDescription() default "";
+}

--- a/src/main/java/com/stempo/api/global/annotation/SuccessApiResponseCustomizer.java
+++ b/src/main/java/com/stempo/api/global/annotation/SuccessApiResponseCustomizer.java
@@ -1,0 +1,48 @@
+package com.stempo.api.global.annotation;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+@Component
+public class SuccessApiResponseCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        SuccessApiResponse successApiResponse = handlerMethod.getMethodAnnotation(SuccessApiResponse.class);
+
+        if (successApiResponse != null) {
+            // ApiResponse DTO 생성 및 설정
+            ApiResponse apiResponse = new ApiResponse()
+                    .description(successApiResponse.description())
+                    .content(new Content().addMediaType("application/json",
+                            new MediaType().schema(createSchema(successApiResponse))));
+
+            // 기존 응답에 추가
+            if (operation.getResponses() != null) {
+                operation.getResponses().addApiResponse("200", apiResponse);
+            }
+        }
+        return operation;
+    }
+
+    private Schema<?> createSchema(SuccessApiResponse successApiResponse) {
+        Schema<?> schema = new Schema<>();
+        schema.setType("object");
+        schema.addProperty("success", new Schema<Boolean>()
+                .type("boolean")
+                .example(true)
+                .description("응답 성공 여부"));
+        schema.addProperty("data", new Schema<>()
+                .type(successApiResponse.dataType().getSimpleName().toLowerCase())
+                .example(successApiResponse.data())
+                .description(successApiResponse.dataDescription()));
+
+        return schema;
+    }
+}

--- a/src/main/java/com/stempo/api/global/config/OpenApiConfig.java
+++ b/src/main/java/com/stempo/api/global/config/OpenApiConfig.java
@@ -1,5 +1,6 @@
 package com.stempo.api.global.config;
 
+import com.stempo.api.global.annotation.SuccessApiResponseCustomizer;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,9 +25,8 @@ public class OpenApiConfig {
     public OpenAPI openAPI(@Value("${springdoc.version}") String appVersion) {
         Info info = new Info().title("Stempo").version(appVersion)
                 .description("Stempo API Document")
-                .termsOfService("http://swagger.io/terms/")
                 .contact(new Contact().name("한관희").url("https://github.com/limehee").email("noop103@naver.com"))
-                .license(new License().name("Stempo License Version 1.0").url("https://github.com/KKKK-Stempo"));
+                .license(new License().name("GNU GENERAL PUBLIC LICENSE v3.0").url("https://www.gnu.org/licenses/gpl-3.0.html"));
 
         final String securitySchemeName = "bearerAuth";
         Server server = new Server().url("/");
@@ -45,5 +46,14 @@ public class OpenApiConfig {
                                 )
                 )
                 .info(info);
+    }
+
+    @Bean
+    public GroupedOpenApi publicApi(SuccessApiResponseCustomizer successApiResponseCustomizer) {
+        return GroupedOpenApi.builder()
+                .group("public")
+                .pathsToMatch("/api/**")
+                .addOperationCustomizer(successApiResponseCustomizer)
+                .build();
     }
 }

--- a/src/main/java/com/stempo/api/global/dto/ApiResponse.java
+++ b/src/main/java/com/stempo/api/global/dto/ApiResponse.java
@@ -2,6 +2,7 @@ package com.stempo.api.global.dto;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +11,10 @@ import lombok.Getter;
 public class ApiResponse<T> {
 
     @Builder.Default
+    @Schema(description = "응답 성공 여부", example = "true")
     private Boolean success = true;
+
+    @Schema(description = "응답 데이터")
     private T data;
 
     public static <T> ApiResponse<T> success() {

--- a/src/main/java/com/stempo/api/global/dto/ErrorResponse.java
+++ b/src/main/java/com/stempo/api/global/dto/ErrorResponse.java
@@ -2,6 +2,7 @@ package com.stempo.api.global.dto;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,8 +11,13 @@ import lombok.Getter;
 public class ErrorResponse<T> {
 
     @Builder.Default
+    @Schema(description = "응답 성공 여부", example = "false")
     private Boolean success = false;
+
+    @Schema(description = "응답 데이터")
     private T data;
+
+    @Schema(description = "에러 메시지(예외명)", example = "NullPointerException")
     private String errorMessage;
 
     public static <T> ErrorResponse<T> failure(Exception e) {

--- a/src/main/java/com/stempo/api/global/dto/PagedResponseDto.java
+++ b/src/main/java/com/stempo/api/global/dto/PagedResponseDto.java
@@ -1,5 +1,6 @@
 package com.stempo.api.global.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,12 +10,25 @@ import java.util.List;
 @Getter
 public class PagedResponseDto<T> {
 
+    @Schema(description = "현재 페이지 번호", example = "0")
     private final int currentPage;
+
+    @Schema(description = "이전 페이지 존재 여부", example = "false")
     private final boolean hasPrevious;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
     private final boolean hasNext;
+
+    @Schema(description = "전체 페이지 수", example = "10")
     private final int totalPages;
+
+    @Schema(description = "전체 아이템 수", example = "100")
     private final long totalItems;
+
+    @Schema(description = "현재 페이지 아이템 수", example = "10")
     private final int take;
+
+    @Schema(description = "현재 페이지 아이템 목록")
     private final List<T> items;
 
     public PagedResponseDto(Page<T> page) {


### PR DESCRIPTION
## Summary

> #64 

현재 Springdoc(Swagger)을 통해 API 문서화가 이루어지고 있지만, 응답에 대한 예제값 설정에 대한 문서화가 누락되어 있습니다. 이 PR에서는 누락된 정보를 추가하여 API 사용자가 응답 형식을 더 명확하게 이해하고, 클라이언트가 요청 결과를 올바르게 처리할 수 있도록 합니다.

## Tasks

- 응답 예제값 설정
    - Springdoc 어노테이션을 사용하여 각 ResponseDto에 대한 예제값 설정
    - 각 필드의 설명과 예제값을 명확하게 문서화