### PR TITLE
feat: 서버 보안 강화 완료

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -15,7 +15,9 @@ object Dependencies {
     const val jjwtImpl = "io.jsonwebtoken:jjwt-impl:${Versions.jjwt}"
     const val jjwtJackson = "io.jsonwebtoken:jjwt-jackson:${Versions.jjwt}"
     const val commonsIo = "commons-io:commons-io:${Versions.commonsIo}"
+    const val commonText = "org.apache.commons:commons-text:${Versions.commonText}"
     const val gson = "com.google.code.gson:gson:${Versions.gson}"
+    const val owaspJavaHtmlSanitizer = "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:${Versions.owaspJavaHtmlSanitizer}"
 
     // Test dependencies
     const val springBootStarterTest = "org.springframework.boot:spring-boot-starter-test"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,6 +18,7 @@ object Dependencies {
     const val commonText = "org.apache.commons:commons-text:${Versions.commonText}"
     const val gson = "com.google.code.gson:gson:${Versions.gson}"
     const val owaspJavaHtmlSanitizer = "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:${Versions.owaspJavaHtmlSanitizer}"
+    const val googleAuthenticator = "com.warrenstrange:googleauth:${Versions.googleAuthenticator}"
 
     // Test dependencies
     const val springBootStarterTest = "org.springframework.boot:spring-boot-starter-test"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,5 +7,7 @@ object Versions {
     const val mariadb = "3.4.1"
     const val jjwt = "0.12.6"
     const val commonsIo = "2.17.0"
+    const val commonText = "1.12.0"
     const val gson = "2.10.1"
+    const val owaspJavaHtmlSanitizer = "20240325.1"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -10,4 +10,5 @@ object Versions {
     const val commonText = "1.12.0"
     const val gson = "2.10.1"
     const val owaspJavaHtmlSanitizer = "20240325.1"
+    const val googleAuthenticator = "1.5.0"
 }

--- a/stempo-api/src/main/java/com/stempo/controller/AuthController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.stempo.annotation.SuccessApiResponse;
 import com.stempo.dto.ApiResponse;
 import com.stempo.dto.TokenInfo;
 import com.stempo.dto.request.AuthRequestDto;
+import com.stempo.dto.request.TwoFactorAuthenticationRequestDto;
 import com.stempo.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,10 +46,10 @@ public class AuthController {
     @Operation(summary = "로그인", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>" +
             "일반 계정일 경우 Device-Tag만 기입하면 됨")
     @PostMapping("/api/v1/auth/login")
-    public ApiResponse<TokenInfo> login(
+    public ApiResponse<Object> login(
             @Valid @RequestBody AuthRequestDto requestDto
     ) {
-        TokenInfo token = authService.login(requestDto);
+        Object token = authService.login(requestDto);
         return ApiResponse.success(token);
     }
 
@@ -59,5 +61,24 @@ public class AuthController {
     ) {
         TokenInfo token = authService.reissueToken(request);
         return ApiResponse.success(token);
+    }
+
+    @Operation(summary = "TOTP 인증", description = "ROLE_ANONYMOUS 권한이 필요함")
+    @PostMapping("/api/v1/auth/two-factor-authentication")
+    public ApiResponse<TokenInfo> authenticate(
+            @Valid @RequestBody TwoFactorAuthenticationRequestDto requestDto
+    ) {
+        TokenInfo token = authService.authenticate(requestDto);
+        return ApiResponse.success(token);
+    }
+
+    @Operation(summary = "[A] TOTP 초기화", description = "ROLE_ADMIN 권한이 필요함")
+    @DeleteMapping("/api/v1/auth/two-factor-authentication/{deviceTag}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<String> resetAuthenticator(
+            @PathVariable(name = "deviceTag") String deviceTag
+    ) {
+        String id = authService.resetAuthenticator(deviceTag);
+        return ApiResponse.success(id);
     }
 }

--- a/stempo-api/src/main/java/com/stempo/controller/AuthController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/AuthController.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,7 +34,7 @@ public class AuthController {
 
     @Operation(summary = "[U] 회원 탈퇴", description = "ROLE_USER 이상의 권한이 필요함")
     @SuccessApiResponse(data = "deviceTag", dataType = String.class, dataDescription = "사용자의 디바이스 식별자")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/api/v1/auth/unregister")
     public ApiResponse<String> unregisterUser() {
         String deviceTag = authService.unregisterUser();
@@ -52,7 +52,7 @@ public class AuthController {
     }
 
     @Operation(summary = "[U] 토큰 재발급", description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/api/v1/auth/reissue")
     public ApiResponse<TokenInfo> reissueToken(
             HttpServletRequest request

--- a/stempo-api/src/main/java/com/stempo/controller/BoardController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/BoardController.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -38,7 +38,7 @@ public class BoardController {
     @Operation(summary = "[U] 게시글 작성", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "공지사항은 ROLE_ADMIN 이상의 권한이 필요함")
     @SuccessApiResponse(data = "boardId", dataType = Long.class, dataDescription = "게시글 ID")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/api/v1/boards")
     public ApiResponse<Long> registerBoard(
             @Valid @RequestBody BoardRequestDto requestDto
@@ -50,7 +50,7 @@ public class BoardController {
     @Operation(summary = "[U] 카테고리별 게시글 조회", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "건의하기는 ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/api/v1/boards")
     public ApiResponse<PagedResponseDto<BoardResponseDto>> getBoardsByCategory(
             @RequestParam(name = "category") BoardCategory category,
@@ -67,7 +67,7 @@ public class BoardController {
     @Operation(summary = "[U] 게시글 수정", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "ADMIN은 모든 게시글 수정 가능")
     @SuccessApiResponse(data = "boardId", dataType = Long.class, dataDescription = "게시글 ID")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/api/v1/boards/{boardId}")
     public ApiResponse<Long> updateBoard(
             @PathVariable(name = "boardId") Long boardId,
@@ -80,7 +80,7 @@ public class BoardController {
     @Operation(summary = "[U] 게시글 삭제", description = "ROLE_USER 이상의 권한이 필요함<br>" +
             "ADMIN은 모든 게시글 삭제 가능")
     @SuccessApiResponse(data = "boardId", dataType = Long.class, dataDescription = "게시글 ID")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/api/v1/boards/{boardId}")
     public ApiResponse<Long> deleteBoard(
             @PathVariable(name = "boardId") Long boardId

--- a/stempo-api/src/main/java/com/stempo/controller/FileController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/FileController.java
@@ -15,7 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,7 +36,7 @@ public class FileController {
 
     @Operation(summary = "[U] 게시판 파일 업로드", description = "ROLE_USER 이상의 권한이 필요함")
     @SuccessApiResponse(data = "[\"filePath1\", \"filePath2\"]", dataType = List.class, dataDescription = "파일 경로 리스트")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/api/v1/files/boards", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<List<String>> boardFileUpload(
             @RequestParam(name = "multipartFile", required = false) List<MultipartFile> multipartFiles
@@ -47,7 +47,7 @@ public class FileController {
 
     @Operation(summary = "[A] 파일 목록 조회", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/api/v1/files")
     public ApiResponse<PagedResponseDto<UploadedFileResponseDto>> getFiles(
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -63,7 +63,7 @@ public class FileController {
     @Operation(summary = "[A] 파일 삭제", description = "ROLE_ADMIN 이상의 권한이 필요함<br>" +
             "파일 경로(/resources/files/)를 받아 해당 파일을 삭제함")
     @SuccessApiResponse(data = "true", dataType = Boolean.class, dataDescription = "파일 삭제 여부")
-    @Secured({ "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/api/v1/files")
     public ApiResponse<Boolean> deleteFile(
             @Valid @RequestBody DeleteFileRequestDto requestDto

--- a/stempo-api/src/main/java/com/stempo/controller/HomeworkController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/HomeworkController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,7 +36,7 @@ public class HomeworkController {
 
     @Operation(summary = "[U] 과제 추가", description = "ROLE_USER 이상의 권한이 필요함")
     @SuccessApiResponse(data = "homeworkId", dataType = Long.class, dataDescription = "과제 ID")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/api/v1/homeworks")
     public ApiResponse<Long> addHomework(
             @Valid @RequestBody HomeworkRequestDto requestDto
@@ -49,7 +49,7 @@ public class HomeworkController {
             "completed(Optional)가 true이면 완료된 과제, false이면 미완료된 과제를 조회함<br>" +
             "completed가 없으면 모든 과제를 조회함<br>" +
             "DTO의 필드명을 기준으로 정렬 가능하며, 정렬 방향은 오름차순(asc)과 내림차순(desc)이 가능함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping(value = "/api/v1/homeworks")
     public ApiResponse<PagedResponseDto<HomeworkResponseDto>> getHomeworks(
             @RequestParam(name = "completed", required = false) Boolean completed,
@@ -65,7 +65,7 @@ public class HomeworkController {
 
     @Operation(summary = "[U] 과제 수정", description = "ROLE_USER 이상의 권한이 필요함")
     @SuccessApiResponse(data = "homeworkId", dataType = Long.class, dataDescription = "과제 ID")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping(value = "/api/v1/homeworks/{homeworkId}")
     public ApiResponse<Long> updateHomework(
             @PathVariable(name = "homeworkId") Long homeworkId,
@@ -77,7 +77,7 @@ public class HomeworkController {
 
     @Operation(summary = "[U] 과제 삭제", description = "ROLE_USER 이상의 권한이 필요함")
     @SuccessApiResponse(data = "homeworkId", dataType = Long.class, dataDescription = "과제 ID")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping(value = "/api/v1/homeworks/{homeworkId}")
     public ApiResponse<Long> deleteHomework(
             @PathVariable(name = "homeworkId") Long homeworkId

--- a/stempo-api/src/main/java/com/stempo/controller/RecordController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/RecordController.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,7 +29,7 @@ public class RecordController {
 
     @Operation(summary = "[U] 보행 훈련 기록", description = "ROLE_USER 이상의 권한이 필요함")
     @SuccessApiResponse(data = "deviceTag", dataType = String.class, dataDescription = "사용자의 디바이스 식별자")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/api/v1/records")
     public ApiResponse<String> record(
             @Valid @RequestBody RecordRequestDto requestDto
@@ -42,7 +42,7 @@ public class RecordController {
             "startDate와 endDate는 yyyy-MM-dd 형식으로 입력해야 함<br>" +
             "startDate 이전의 가장 최신 데이터와 startDate부터 endDate까지의 데이터를 가져옴<br>" +
             "데이터가 없을 경우 startDate 이전 날짜, 정확도 0으로 설정하여 반환")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/api/v1/records")
     public ApiResponse<List<RecordResponseDto>> getRecords(
             @RequestParam(name = "startDate") LocalDate startDate,
@@ -53,7 +53,7 @@ public class RecordController {
     }
 
     @Operation(summary = "[U] 내 보행 훈련 기록 통계" , description = "ROLE_USER 이상의 권한이 필요함")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/api/v1/records/statistics")
     public ApiResponse<RecordStatisticsResponseDto> getRecordStatistics() {
         RecordStatisticsResponseDto statistics = recordService.getRecordStatistics();

--- a/stempo-api/src/main/java/com/stempo/controller/RhythmController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/RhythmController.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +24,7 @@ public class RhythmController {
             "BPM은 10 이상 200 이하의 값이어야 함<br>" +
             "Bit는 1 이상 8 이하의 값이어야 함")
     @SuccessApiResponse(data = "/resources/files/{fileName}", dataType = String.class, dataDescription = "파일 경로")
-    @Secured({ "ROLE_USER", "ROLE_ADMIN" })
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/api/v1/rhythm")
     public ApiResponse<String> generateRhythm(
             @Valid @RequestBody RhythmRequestDto requestDto

--- a/stempo-api/src/main/java/com/stempo/exception/ApiExceptionHandler.java
+++ b/stempo-api/src/main/java/com/stempo/exception/ApiExceptionHandler.java
@@ -52,7 +52,6 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ApiResponse<Void> handleServerError(HttpServletRequest request, HttpServletResponse response, Exception e) {
-        log.error("Server Error: {}", e.getMessage());
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         return ApiResponse.failure();
     }

--- a/stempo-api/src/main/java/com/stempo/interceptor/ApiLoggingInterceptor.java
+++ b/stempo-api/src/main/java/com/stempo/interceptor/ApiLoggingInterceptor.java
@@ -1,12 +1,10 @@
 package com.stempo.interceptor;
 
-import com.stempo.util.HttpReqResUtils;
+import com.stempo.util.ApiLogger;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -15,28 +13,13 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class ApiLoggingInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) {
         request.setAttribute("startTime", System.currentTimeMillis());
         return true;
     }
 
     @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, @NotNull Object handler, Exception ex) throws Exception {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
-        String clientIpAddress = HttpReqResUtils.getClientIpAddressIfServletRequestExist();
-        String requestUrl = request.getRequestURI();
-        String httpMethod = request.getMethod();
-        int httpStatus = response.getStatus();
-
-        long startTime = (Long) request.getAttribute("startTime");
-        long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-
-        if (ex == null) {
-            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, requestUrl, httpMethod, httpStatus, duration);
-        } else {
-            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, requestUrl, httpMethod, httpStatus, duration, ex.getMessage());
-        }
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, @NotNull Object handler, Exception ex) {
+        ApiLogger.logRequestDuration(request, response, ex);
     }
 }

--- a/stempo-application/build.gradle.kts
+++ b/stempo-application/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     implementation(Dependencies.jakartaValidationApi)
     implementation(Dependencies.hibernateValidator)
     implementation(Dependencies.swagger)
+    implementation(Dependencies.googleAuthenticator)
 }

--- a/stempo-application/src/main/java/com/stempo/config/AuthenticatorConfig.java
+++ b/stempo-application/src/main/java/com/stempo/config/AuthenticatorConfig.java
@@ -1,0 +1,14 @@
+package com.stempo.config;
+
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AuthenticatorConfig {
+
+    @Bean
+    public GoogleAuthenticator googleAuthenticator() {
+        return new GoogleAuthenticator();
+    }
+}

--- a/stempo-application/src/main/java/com/stempo/dto/request/TwoFactorAuthenticationRequestDto.java
+++ b/stempo-application/src/main/java/com/stempo/dto/request/TwoFactorAuthenticationRequestDto.java
@@ -1,0 +1,19 @@
+package com.stempo.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TwoFactorAuthenticationRequestDto {
+
+    @NotNull(message = "Device Tag is required")
+    @Schema(description = "디바이스 식별자", example = "490154203237518", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String deviceTag;
+
+    @NotNull(message = "TOTP is required")
+    @Schema(description = "TOTP", example = "123456", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String totp;
+}

--- a/stempo-application/src/main/java/com/stempo/exception/AccountLockedException.java
+++ b/stempo-application/src/main/java/com/stempo/exception/AccountLockedException.java
@@ -1,0 +1,8 @@
+package com.stempo.exception;
+
+public class AccountLockedException extends RuntimeException {
+
+    public AccountLockedException(String message) {
+        super(message);
+    }
+}

--- a/stempo-application/src/main/java/com/stempo/exception/ApplicationExceptionHandler.java
+++ b/stempo-application/src/main/java/com/stempo/exception/ApplicationExceptionHandler.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionException;
 public class ApplicationExceptionHandler {
 
     @ExceptionHandler({
+            InvalidPasswordException.class,
             StringIndexOutOfBoundsException.class,
             IllegalAccessException.class,
             NumberFormatException.class,

--- a/stempo-application/src/main/java/com/stempo/exception/ApplicationExceptionHandler.java
+++ b/stempo-application/src/main/java/com/stempo/exception/ApplicationExceptionHandler.java
@@ -51,6 +51,12 @@ public class ApplicationExceptionHandler {
         return ErrorResponse.failure(e);
     }
 
+    @ExceptionHandler(AccountLockedException.class)
+    public ErrorResponse<Exception> handleAccountLocked(HttpServletResponse response, AccountLockedException e) {
+        response.setStatus(423); // 423 Locked
+        return ErrorResponse.failure(e);
+    }
+
     @ExceptionHandler({
             IllegalStateException.class,
             FileUploadFailException.class,
@@ -64,7 +70,6 @@ public class ApplicationExceptionHandler {
             Exception.class
     })
     public ApiResponse<Void> handleServerError(HttpServletRequest request, HttpServletResponse response, Exception e) {
-        log.error("Server Error: {}", e.getMessage());
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         return ApiResponse.failure();
     }

--- a/stempo-application/src/main/java/com/stempo/exception/InvalidPasswordException.java
+++ b/stempo-application/src/main/java/com/stempo/exception/InvalidPasswordException.java
@@ -1,0 +1,8 @@
+package com.stempo.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/stempo-application/src/main/java/com/stempo/service/AuthService.java
+++ b/stempo-application/src/main/java/com/stempo/service/AuthService.java
@@ -2,6 +2,7 @@ package com.stempo.service;
 
 import com.stempo.dto.TokenInfo;
 import com.stempo.dto.request.AuthRequestDto;
+import com.stempo.dto.request.TwoFactorAuthenticationRequestDto;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthService {
@@ -10,7 +11,11 @@ public interface AuthService {
 
     String unregisterUser();
 
-    TokenInfo login(AuthRequestDto requestDto);
+    Object login(AuthRequestDto requestDto);
 
     TokenInfo reissueToken(HttpServletRequest request);
+
+    TokenInfo authenticate(TwoFactorAuthenticationRequestDto requestDto);
+
+    String resetAuthenticator(String deviceTag);
 }

--- a/stempo-application/src/main/java/com/stempo/service/AuthServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/AuthServiceImpl.java
@@ -38,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenInfo registerUser(AuthRequestDto requestDto) {
         String deviceTag = encryptDeviceTag(requestDto.getDeviceTag());
-        String password = encryptPassword(requestDto.getPassword());
+        String password = encryptPassword(requestDto.getPassword().trim());
 
         if (userService.existsById(deviceTag)) {
             throw new UserAlreadyExistsException("User already exists.");
@@ -82,7 +82,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private String encryptPassword(String password) {
-        return StringUtils.hasText(password) ? null : passwordEncoder.encode(password);
+        return !StringUtils.hasLength(password) ? null : passwordEncoder.encode(password);
     }
 
     private void validateRefreshToken(String refreshToken) {

--- a/stempo-application/src/main/java/com/stempo/service/TotpAuthenticatorService.java
+++ b/stempo-application/src/main/java/com/stempo/service/TotpAuthenticatorService.java
@@ -1,0 +1,12 @@
+package com.stempo.service;
+
+public interface TotpAuthenticatorService {
+
+    String resetAuthenticator(String deviceTag);
+
+    boolean isAuthenticatorValid(String deviceTag, String totp);
+
+    boolean isAuthenticatorExist(String deviceTag);
+
+    String generateSecretKey(String deviceTag);
+}

--- a/stempo-application/src/main/java/com/stempo/service/TotpAuthenticatorServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/TotpAuthenticatorServiceImpl.java
@@ -1,0 +1,60 @@
+package com.stempo.service;
+
+import com.stempo.model.TotpAuthenticator;
+import com.stempo.repository.TotpAuthenticatorRepository;
+import com.stempo.util.EncryptionUtils;
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TotpAuthenticatorServiceImpl implements TotpAuthenticatorService {
+
+    private final TotpAuthenticatorRepository repository;
+    private final GoogleAuthenticator googleAuthenticator;
+    private final EncryptionUtils encryptionUtils;
+
+    @Override
+    @Transactional
+    public String resetAuthenticator(String deviceTag) {
+        TotpAuthenticator authenticator = repository.getById(deviceTag);
+        repository.delete(authenticator);
+        return deviceTag;
+    }
+
+    @Override
+    @Transactional
+    public String generateSecretKey(String deviceTag) {
+        GoogleAuthenticatorKey key = googleAuthenticator.createCredentials();
+        String secretKey = key.getKey();
+        saveAuthenticator(deviceTag, secretKey);
+        return secretKey;
+    }
+
+    @Override
+    public boolean isAuthenticatorValid(String deviceTag, String totp) {
+        Optional<TotpAuthenticator> authenticatorOpt = repository.findById(deviceTag);
+        return authenticatorOpt.isPresent() && validateTotp(authenticatorOpt.get(), totp);
+    }
+
+    private boolean validateTotp(TotpAuthenticator authenticator, String totp) {
+        String secretKey = encryptionUtils.decrypt(authenticator.getSecretKey());
+        return googleAuthenticator.authorize(secretKey, Integer.parseInt(totp));
+    }
+
+    private void saveAuthenticator(String deviceTag, String secretKey) {
+        String encryptedSecretKey = encryptionUtils.encrypt(secretKey);
+        TotpAuthenticator authenticator = TotpAuthenticator.create(deviceTag, encryptedSecretKey);
+        repository.save(authenticator);
+    }
+
+    @Override
+    public boolean isAuthenticatorExist(String deviceTag) {
+        return repository.existsById(deviceTag);
+    }
+}

--- a/stempo-application/src/main/java/com/stempo/service/UserService.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserService.java
@@ -11,6 +11,8 @@ public interface UserService {
 
     boolean existsById(String deviceTag);
 
+    User getById(String deviceTag);
+
     User save(User user);
 
     void delete(User user);

--- a/stempo-application/src/main/java/com/stempo/service/UserService.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserService.java
@@ -18,4 +18,10 @@ public interface UserService {
     String getCurrentDeviceTag();
 
     User getCurrentUser();
+
+    void handleAccountLock(String deviceTag);
+
+    void handleFailedLogin(String deviceTag);
+
+    void resetFailedAttempts(String deviceTag);
 }

--- a/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
@@ -60,6 +60,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public void handleAccountLock(String deviceTag) {
         User user = findById(deviceTag)
                 .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));

--- a/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
@@ -62,8 +62,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void handleAccountLock(String deviceTag) {
-        User user = findById(deviceTag)
-                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+        User user = getUserById(deviceTag);
         if (user.isAccountLocked()) {
             throw new AccountLockedException("Account is locked due to too many failed login attempts.");
         }
@@ -72,8 +71,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void handleFailedLogin(String deviceTag) {
-        User user = repository.findById(deviceTag)
-                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+        User user = getUserById(deviceTag);
         user.incrementFailedLoginAttempts();
         if (user.getFailedLoginAttempts() >= maxFailedAttempts) {
             user.lockAccount();
@@ -85,9 +83,13 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void resetFailedAttempts(String deviceTag) {
-        User user = repository.findById(deviceTag)
-                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+        User user = getUserById(deviceTag);
         user.resetFailedLoginAttempts();
         save(user);
+    }
+
+    private User getUserById(String deviceTag) {
+        return findById(deviceTag)
+                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
     }
 }

--- a/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
@@ -3,7 +3,7 @@ package com.stempo.service;
 import com.stempo.exception.AccountLockedException;
 import com.stempo.model.User;
 import com.stempo.repository.UserRepository;
-import com.stempo.util.AuthUtil;
+import com.stempo.util.AuthUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,7 +50,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public String getCurrentDeviceTag() {
-        return AuthUtil.getAuthenticationInfoDeviceTag();
+        return AuthUtils.getAuthenticationInfoDeviceTag();
     }
 
     @Override

--- a/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
@@ -1,18 +1,27 @@
 package com.stempo.service;
 
+import com.stempo.exception.AccountLockedException;
 import com.stempo.model.User;
 import com.stempo.repository.UserRepository;
 import com.stempo.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserServiceImpl implements UserService {
 
     private final UserRepository repository;
+
+    @Value("${security.max-failed-attempts}")
+    private int maxFailedAttempts;
 
     @Override
     public Optional<User> findById(String id) {
@@ -43,5 +52,36 @@ public class UserServiceImpl implements UserService {
     public User getCurrentUser() {
         String deviceTag = getCurrentDeviceTag();
         return repository.findByIdOrThrow(deviceTag);
+    }
+
+    @Override
+    public void handleAccountLock(String deviceTag) {
+        User user = findById(deviceTag)
+                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+        if (user.isAccountLocked()) {
+            throw new AccountLockedException("Account is locked due to too many failed login attempts.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void handleFailedLogin(String deviceTag) {
+        User user = repository.findById(deviceTag)
+                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+        user.incrementFailedLoginAttempts();
+        if (user.getFailedLoginAttempts() >= maxFailedAttempts) {
+            user.lockAccount();
+            log.warn("User {} account locked after {} failed login attempts", user.getDeviceTag(), maxFailedAttempts);
+        }
+        save(user);
+    }
+
+    @Override
+    @Transactional
+    public void resetFailedAttempts(String deviceTag) {
+        User user = repository.findById(deviceTag)
+                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+        user.resetFailedLoginAttempts();
+        save(user);
     }
 }

--- a/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
@@ -34,6 +34,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public User getById(String deviceTag) {
+        return repository.findByIdOrThrow(deviceTag);
+    }
+
+    @Override
     public User save(User user) {
         return repository.save(user);
     }

--- a/stempo-auth/build.gradle.kts
+++ b/stempo-auth/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
     runtimeOnly(Dependencies.jjwtImpl)
     runtimeOnly(Dependencies.jjwtJackson)
 
+    // XSS Sanitizer
+    implementation(Dependencies.owaspJavaHtmlSanitizer)
+
     // Test dependencies
     testImplementation(Dependencies.springSecurityTest)
 }

--- a/stempo-auth/src/main/java/com/stempo/config/AuthenticationConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/AuthenticationConfig.java
@@ -4,21 +4,60 @@ import com.stempo.application.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+import java.util.Arrays;
 
 @Configuration
 @RequiredArgsConstructor
 public class AuthenticationConfig {
 
     private final CustomUserDetailsService customUserDetailsService;
+    private final WhitelistProperties whitelistProperties;
 
+    // 화이트리스트용 DaoAuthenticationProvider 설정
+    @Bean
+    public DaoAuthenticationProvider whitelistAuthenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(whitelistUserDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    // 화이트리스트 사용자에 대한 InMemoryUserDetailsManager 설정
+    @Bean
+    public InMemoryUserDetailsManager whitelistUserDetailsService() {
+        UserDetails user = User.withUsername(whitelistProperties.getAccount().getUsername())
+                .password(passwordEncoder().encode(whitelistProperties.getAccount().getPassword()))
+                .roles(whitelistProperties.getAccount().getRole())
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    // 일반 사용자용 CustomAuthenticationProvider 설정
     @Bean
     public CustomAuthenticationProvider customAuthenticationProvider() {
         return new CustomAuthenticationProvider(customUserDetailsService, passwordEncoder());
     }
 
+    // BCryptPasswordEncoder 설정
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // 두 가지 인증 프로바이더를 함께 사용하는 AuthenticationManager 설정
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(Arrays.asList(
+                customAuthenticationProvider(), // 일반 사용자용 프로바이더
+                whitelistAuthenticationProvider() // 화이트리스트용 프로바이더
+        ));
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/config/AuthorizeRequestsCustomizer.java
+++ b/stempo-auth/src/main/java/com/stempo/config/AuthorizeRequestsCustomizer.java
@@ -1,0 +1,27 @@
+package com.stempo.config;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthorizeRequestsCustomizer {
+
+    private final WhitelistProperties whitelistProperties;
+
+    @Bean
+    public @NotNull Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> authorizeHttpRequestsConfig() {
+        return (authorize) -> authorize
+                .requestMatchers(SecurityConstants.PERMIT_ALL).permitAll()
+                .requestMatchers(HttpMethod.GET, SecurityConstants.PERMIT_ALL_API_ENDPOINTS_GET).permitAll()
+                .requestMatchers(HttpMethod.POST, SecurityConstants.PERMIT_ALL_API_ENDPOINTS_POST).permitAll()
+                .requestMatchers(whitelistProperties.getPatterns().getWhitelistPatterns()).hasRole(whitelistProperties.getAccount().getRole())
+                .anyRequest().authenticated();
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/config/RoleHierarchyConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/RoleHierarchyConfig.java
@@ -1,0 +1,17 @@
+package com.stempo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+
+@Configuration
+public class RoleHierarchyConfig {
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.fromHierarchy("""
+                ROLE_ADMIN > ROLE_USER
+                """);
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/config/SecurityConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.stempo.filter.CustomBasicAuthenticationFilter;
 import com.stempo.filter.JwtAuthenticationFilter;
 import com.stempo.util.ApiLogger;
 import com.stempo.util.HttpReqResUtils;
+import com.stempo.util.IpWhitelistValidator;
 import com.stempo.util.ResponseUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,6 +36,7 @@ public class SecurityConfig {
     private final AuthenticationManager authenticationManager;
     private final Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> authorizeHttpRequestsCustomizer;
     private final JwtTokenService tokenService;
+    private final IpWhitelistValidator ipWhitelistValidator;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -47,7 +49,7 @@ public class SecurityConfig {
                         authorizeHttpRequestsCustomizer
                 )
                 .addFilterBefore(
-                        new CustomBasicAuthenticationFilter(authenticationManager),
+                        new CustomBasicAuthenticationFilter(authenticationManager, ipWhitelistValidator),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterBefore(

--- a/stempo-auth/src/main/java/com/stempo/config/SecurityConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/SecurityConfig.java
@@ -2,21 +2,30 @@ package com.stempo.config;
 
 import com.stempo.application.JwtTokenService;
 import com.stempo.filter.JwtAuthenticationFilter;
+import com.stempo.util.ApiLogger;
+import com.stempo.util.HttpReqResUtils;
+import com.stempo.util.ResponseUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.io.IOException;
+
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
-@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
     private final JwtTokenService tokenService;
@@ -34,7 +43,32 @@ public class SecurityConfig {
                 .addFilterBefore(
                         new JwtAuthenticationFilter(tokenService),
                         UsernamePasswordAuthenticationFilter.class
+                )
+                .exceptionHandling(httpSecurityExceptionHandlingConfigurer ->
+                        httpSecurityExceptionHandlingConfigurer
+                                .authenticationEntryPoint(this::handleException)
+                                .accessDeniedHandler(this::handleException)
                 );
         return http.build();
+    }
+
+    private void handleException(HttpServletRequest request, HttpServletResponse response, Exception exception) throws IOException {
+        String clientIpAddress = HttpReqResUtils.getClientIpAddressIfServletRequestExist();
+        String message;
+        int statusCode;
+
+        if (exception instanceof AuthenticationException) {
+            message = "인증되지 않은 사용자의 비정상적인 접근이 감지되었습니다.";
+            statusCode = HttpServletResponse.SC_UNAUTHORIZED;
+        } else if (exception instanceof AccessDeniedException) {
+            message = "권한이 없는 엔드포인트에 대한 접근이 감지되었습니다.";
+            statusCode = HttpServletResponse.SC_FORBIDDEN;
+        } else {
+            message = "비정상적인 접근이 감지되었습니다.";
+            statusCode = HttpServletResponse.SC_BAD_REQUEST;
+        }
+
+        ApiLogger.logRequest(request, response, clientIpAddress, message);
+        ResponseUtils.sendErrorResponse(response, statusCode);
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/config/SecurityConstants.java
+++ b/stempo-auth/src/main/java/com/stempo/config/SecurityConstants.java
@@ -16,5 +16,6 @@ public class SecurityConstants {
     public static final String[] PERMIT_ALL_API_ENDPOINTS_POST = {
             "/api/v1/auth/register",
             "/api/v1/auth/login",
+            "/api/v1/auth/two-factor-authentication"
     };
 }

--- a/stempo-auth/src/main/java/com/stempo/config/SecurityConstants.java
+++ b/stempo-auth/src/main/java/com/stempo/config/SecurityConstants.java
@@ -1,0 +1,20 @@
+package com.stempo.config;
+
+public class SecurityConstants {
+
+    public static final String[] PERMIT_ALL = {
+            "/actuator/health",
+            "/resources/files/**",
+            "/favicon.ico",
+            "/error",
+            "/"
+    };
+
+    public static final String[] PERMIT_ALL_API_ENDPOINTS_GET = {
+    };
+
+    public static final String[] PERMIT_ALL_API_ENDPOINTS_POST = {
+            "/api/v1/auth/register",
+            "/api/v1/auth/login",
+    };
+}

--- a/stempo-auth/src/main/java/com/stempo/config/ValidatorConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/ValidatorConfig.java
@@ -1,0 +1,14 @@
+package com.stempo.config;
+
+import com.stempo.util.PasswordValidator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ValidatorConfig {
+
+    @Bean
+    public PasswordValidator passwordValidator() {
+        return new PasswordValidator();
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/config/WhitelistProperties.java
+++ b/stempo-auth/src/main/java/com/stempo/config/WhitelistProperties.java
@@ -1,0 +1,43 @@
+package com.stempo.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "security.whitelist")
+public class WhitelistProperties {
+
+    private boolean enabled;
+    private String path;
+
+    private Account account = new Account();
+    private Patterns patterns = new Patterns();
+
+    @Getter
+    @Setter
+    public static class Account {
+        private String username;
+        private String password;
+        private String role;
+    }
+
+    @Getter
+    @Setter
+    public static class Patterns {
+        private String[] actuator;
+        private String[] apiDocs;
+
+        public String[] getWhitelistPatterns() {
+            return Stream.of(apiDocs, actuator)
+                    .flatMap(Arrays::stream)
+                    .toArray(String[]::new);
+        }
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/config/XssConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/XssConfig.java
@@ -2,7 +2,7 @@ package com.stempo.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stempo.filter.XssEscapeServletFilter;
-import com.stempo.filter.XssSanitizer;
+import com.stempo.util.XssSanitizer;
 import com.stempo.util.HtmlCharacterEscapes;
 import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;

--- a/stempo-auth/src/main/java/com/stempo/config/XssConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/XssConfig.java
@@ -2,8 +2,8 @@ package com.stempo.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stempo.filter.XssEscapeServletFilter;
-import com.stempo.util.XssSanitizer;
 import com.stempo.util.HtmlCharacterEscapes;
+import com.stempo.util.XssSanitizer;
 import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;

--- a/stempo-auth/src/main/java/com/stempo/config/XssConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/XssConfig.java
@@ -1,0 +1,37 @@
+package com.stempo.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.filter.XssEscapeServletFilter;
+import com.stempo.filter.XssSanitizer;
+import com.stempo.util.HtmlCharacterEscapes;
+import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+@Configuration
+@RequiredArgsConstructor
+public class XssConfig {
+
+    private final ObjectMapper mapper;
+    private final XssSanitizer xssSanitizer;
+
+    // JSON 응답에 대해 HTML 이스케이프 필터 적용
+    @Bean
+    public MappingJackson2HttpMessageConverter characterEscapeConverter() {
+        ObjectMapper objectMapper = mapper.copy();
+        objectMapper.getFactory().setCharacterEscapes(new HtmlCharacterEscapes());
+        return new MappingJackson2HttpMessageConverter(objectMapper);
+    }
+
+    // 요청 파라미터 및 폼 데이터에 대한 필터 적용
+    @Bean
+    public FilterRegistrationBean<Filter> xssFilter() {
+        FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new XssEscapeServletFilter(xssSanitizer));
+        registrationBean.setOrder(1);
+        return registrationBean;
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/config/YamlConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/YamlConfig.java
@@ -1,0 +1,19 @@
+package com.stempo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+@Configuration
+public class YamlConfig {
+
+    @Bean
+    public Yaml yamlParser() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setIndent(2);
+        options.setPrettyFlow(true);
+        return new Yaml(options);
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/exception/AuthExceptionHandler.java
+++ b/stempo-auth/src/main/java/com/stempo/exception/AuthExceptionHandler.java
@@ -8,7 +8,9 @@ import io.jsonwebtoken.security.SecurityException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -22,6 +24,8 @@ public class AuthExceptionHandler {
 
     @ExceptionHandler({
             AuthenticationInfoNotFoundException.class,
+            AuthorizationDeniedException.class,
+            AuthorizationServiceException.class,
             BadCredentialsException.class,
             TokenValidateException.class,
             TokenNotFoundException.class,

--- a/stempo-auth/src/main/java/com/stempo/filter/CustomBasicAuthenticationFilter.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/CustomBasicAuthenticationFilter.java
@@ -1,0 +1,82 @@
+package com.stempo.filter;
+
+import com.stempo.util.ResponseUtils;
+import com.stempo.util.WhitelistPathMatcher;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Base64;
+
+@Slf4j
+public class CustomBasicAuthenticationFilter extends BasicAuthenticationFilter {
+
+    private final AuthenticationManager whitelistAuthenticationManager;
+
+    public CustomBasicAuthenticationFilter(AuthenticationManager whitelistAuthenticationManager) {
+        super(whitelistAuthenticationManager);
+        this.whitelistAuthenticationManager = whitelistAuthenticationManager;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String path = request.getRequestURI();
+        if (!WhitelistPathMatcher.isWhitelistRequest(path)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (!authenticateUserCredentials(request, response)) {
+            return;
+        }
+
+        super.doFilterInternal(request, response, chain);
+    }
+
+    private boolean authenticateUserCredentials(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Basic ")) {
+            response.setHeader("WWW-Authenticate", "Basic realm=\"Please enter your username and password\"");
+            ResponseUtils.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        String[] credentials = decodeCredentials(authorizationHeader);
+        if (credentials.length < 2) {
+            ResponseUtils.sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+
+        String username = credentials[0];
+        String password = credentials[1];
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(username, password);
+
+        try {
+            // 화이트리스트용 AuthenticationManager로 인증 처리
+            Authentication authentication = whitelistAuthenticationManager.authenticate(authRequest);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (BadCredentialsException e) {
+            ResponseUtils.sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        return true;
+    }
+
+    @NotNull
+    private static String[] decodeCredentials(String authorizationHeader) {
+        String base64Credentials = authorizationHeader.substring("Basic ".length());
+        String credentials = new String(Base64.getDecoder().decode(base64Credentials));
+        return credentials.split(":", 2);
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/filter/JwtAuthenticationFilter.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.stempo.filter;
 
 import com.stempo.application.JwtTokenService;
+import com.stempo.util.WhitelistPathMatcher;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -24,9 +25,18 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String path = httpServletRequest.getRequestURI();
+
+        // 화이트리스트 경로인 경우 JWT 인증 대신 Basic Auth 인증을 사용
+        if (WhitelistPathMatcher.isWhitelistRequest(path)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         if (!authenticateToken(httpServletRequest)) {
             return;
         }
+
         chain.doFilter(request, response);
     }
 

--- a/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletFilter.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletFilter.java
@@ -1,0 +1,38 @@
+package com.stempo.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class XssEscapeServletFilter implements Filter {
+
+    private final XssSanitizer xssSanitizer;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            HttpServletRequest sanitizedRequest = new XssEscapeServletRequestWrapper((HttpServletRequest) request, xssSanitizer);
+            chain.doFilter(sanitizedRequest, response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletFilter.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletFilter.java
@@ -1,5 +1,6 @@
 package com.stempo.filter;
 
+import com.stempo.util.XssSanitizer;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;

--- a/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletRequestWrapper.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletRequestWrapper.java
@@ -1,5 +1,6 @@
 package com.stempo.filter;
 
+import com.stempo.util.XssSanitizer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 

--- a/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletRequestWrapper.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletRequestWrapper.java
@@ -1,0 +1,53 @@
+package com.stempo.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class XssEscapeServletRequestWrapper extends HttpServletRequestWrapper {
+
+    private final XssSanitizer xssSanitizer;
+
+    public XssEscapeServletRequestWrapper(HttpServletRequest request, XssSanitizer xssSanitizer) {
+        super(request);
+        this.xssSanitizer = xssSanitizer;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        String value = super.getParameter(name);
+        return xssSanitizer.sanitize(value);
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        String[] values = super.getParameterValues(name);
+        return applyFilterToValues(values);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        Map<String, String[]> paramMap = super.getParameterMap();
+        Map<String, String[]> sanitizedMap = new HashMap<>(paramMap.size());
+
+        for (Map.Entry<String, String[]> entry : paramMap.entrySet()) {
+            String[] sanitizedValues = applyFilterToValues(entry.getValue());
+            sanitizedMap.put(entry.getKey(), sanitizedValues);
+        }
+
+        return sanitizedMap;
+    }
+
+    private String[] applyFilterToValues(String[] values) {
+        if (values == null) {
+            return null;
+        }
+        String[] sanitizedValues = new String[values.length];
+        for (int i = 0; i < values.length; i++) {
+            sanitizedValues[i] = xssSanitizer.sanitize(values[i]);
+        }
+        return sanitizedValues;
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/filter/XssSanitizer.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssSanitizer.java
@@ -1,0 +1,29 @@
+package com.stempo.filter;
+
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+import org.springframework.stereotype.Component;
+
+@Component
+public class XssSanitizer {
+
+    private final PolicyFactory policy;
+
+    public XssSanitizer() {
+        // 허용할 태그와 속성 설정 (기본적으로 형식과 링크만 허용)
+        this.policy = Sanitizers.FORMATTING.and(Sanitizers.LINKS);
+    }
+
+    /**
+     * 입력값을 XSS로부터 안전한 값으로 변환
+     *
+     * @param input 사용자 입력 값
+     * @return 필터링된 값
+     */
+    public String sanitize(String input) {
+        if (input == null) {
+            return null;
+        }
+        return this.policy.sanitize(input);
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/util/AuthUtils.java
+++ b/stempo-auth/src/main/java/com/stempo/util/AuthUtils.java
@@ -5,7 +5,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
-public class AuthUtil {
+public class AuthUtils {
 
     public static User getAuthenticationInfo() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/stempo-auth/src/main/java/com/stempo/util/IpAddressUtils.java
+++ b/stempo-auth/src/main/java/com/stempo/util/IpAddressUtils.java
@@ -1,0 +1,21 @@
+package com.stempo.util;
+
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
+
+public class IpAddressUtils {
+
+    /**
+     * 주어진 IP가 특정 서브넷이나 IP 주소와 일치하는지 확인합니다.
+     * @param ipAddress 확인하려는 대상 IP 주소
+     * @param ipOrCidr 서브넷 마스크를 포함한 IP 주소 (예: 192.168.1.0/24 또는 단일 IP 주소)
+     * @return 주어진 IP가 서브넷 내에 있거나 IP 주소와 일치하면 true, 그렇지 않으면 false
+     */
+    public static boolean isIpInRange(String ipAddress, String ipOrCidr) {
+        try {
+            IpAddressMatcher ipAddressMatcher = new IpAddressMatcher(ipOrCidr);
+            return ipAddressMatcher.matches(ipAddress);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/util/IpWhitelistValidator.java
+++ b/stempo-auth/src/main/java/com/stempo/util/IpWhitelistValidator.java
@@ -1,0 +1,38 @@
+package com.stempo.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class IpWhitelistValidator {
+
+    @Value("${security.whitelist.enabled}")
+    private boolean whitelistEnabled;
+    private final WhitelistFileLoader whitelistFileLoader;
+
+    /**
+     * 요청된 IP가 화이트리스트에 포함되는지 확인합니다.
+     * @param ipAddress 확인하려는 IP 주소
+     * @return IP가 화이트리스트에 포함되면 true, 그렇지 않으면 false
+     */
+    public boolean isIpWhitelisted(String ipAddress) {
+        if (!whitelistEnabled) {
+            return true;
+        }
+
+        List<String> whitelistIps = whitelistFileLoader.loadWhitelistIps();
+
+        if (whitelistIps.isEmpty()) {
+            return false;
+        }
+
+        return whitelistIps.stream()
+                .filter(Objects::nonNull)
+                .anyMatch(ip -> "*".equals(ip) || IpAddressUtils.isIpInRange(ipAddress, ip));
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/util/PasswordValidator.java
+++ b/stempo-auth/src/main/java/com/stempo/util/PasswordValidator.java
@@ -1,0 +1,59 @@
+package com.stempo.util;
+
+import java.util.regex.Pattern;
+
+public class PasswordValidator {
+
+    // 최소 8자리 이상, 최대 16자리 이하
+    private static final String LENGTH_PATTERN = "^.{8,16}$";
+
+    // 영문 대소문자, 숫자, 특수문자 중 3가지 이상 포함
+    private static final String CHARACTER_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[@#$%^&+=!]).{8,16}$";
+
+    // 연속된 숫자나 동일한 문자 3개 이상 금지
+    private static final String SEQUENTIAL_PATTERN = "(\\w)\\1\\1";
+
+    private final Pattern lengthPattern;
+    private final Pattern characterPattern;
+    private final Pattern sequentialPattern;
+
+    public PasswordValidator() {
+        this.lengthPattern = Pattern.compile(LENGTH_PATTERN);
+        this.characterPattern = Pattern.compile(CHARACTER_PATTERN);
+        this.sequentialPattern = Pattern.compile(SEQUENTIAL_PATTERN);
+    }
+
+    public boolean isValid(String password, String username) {
+        // 비밀번호가 null인 경우는 유효성 검사를 통과
+        if (password == null) {
+            return true;
+        }
+
+        // 비밀번호에 공백이 포함되어 있는지 확인
+        if (password.contains(" ")) {
+            return false;
+        }
+
+        // 비밀번호 길이 확인 (8 ~ 16자리)
+        if (!lengthPattern.matcher(password).matches()) {
+            return false;
+        }
+
+        // 영문 대소문자, 숫자, 특수문자 중 3가지 이상 포함 여부 확인
+        if (!characterPattern.matcher(password).matches()) {
+            return false;
+        }
+
+        // 연속된 숫자나 동일한 문자 3개 이상 확인
+        if (sequentialPattern.matcher(password).find()) {
+            return false;
+        }
+
+        // 비밀번호에 username(아이디)와 4자 이상 동일한 문자 포함 여부 확인
+        if (username != null && password.contains(username)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/util/WhitelistFileLoader.java
+++ b/stempo-auth/src/main/java/com/stempo/util/WhitelistFileLoader.java
@@ -1,0 +1,102 @@
+package com.stempo.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WhitelistFileLoader {
+
+    private final Yaml yaml;
+    private final Lock fileLock = new ReentrantLock();
+
+    @Value("${security.whitelist.path}")
+    private String whitelistPath;
+
+    /**
+     * 화이트리스트 YAML 파일에서 IP 목록을 로드합니다.
+     * @return 화이트리스트에 포함된 IP 목록
+     */
+    public List<String> loadWhitelistIps() {
+        fileLock.lock();
+        try {
+            Path path = Paths.get(whitelistPath);
+
+            if (Files.notExists(path)) {
+                createDefaultWhitelistFile(path, yaml);
+            }
+
+            return parseWhitelistFile(yaml, path);
+        } catch (IOException e) {
+            log.error("Failed to load or create IP whitelist", e);
+            return List.of();
+        } finally {
+            fileLock.unlock();
+        }
+    }
+
+    /**
+     * 기본 화이트리스트 YAML 파일을 생성합니다.
+     * @param path 파일 경로
+     * @param yaml Yaml 객체
+     * @throws IOException 파일 생성 중 오류 발생 시
+     */
+    private void createDefaultWhitelistFile(Path path, Yaml yaml) throws IOException {
+        Files.createDirectories(path.getParent());
+        Map<String, Map<String, List<String>>> defaultContent = Map.of(
+                "whitelist", Map.of(
+                        "fixedIps", List.of(""),
+                        "temporaryIps", List.of("*")
+                )
+        );
+        yaml.dump(defaultContent, Files.newBufferedWriter(path));
+        log.info("Whitelist YAML file created at {}", whitelistPath);
+    }
+
+    /**
+     * YAML 파일을 파싱하여 화이트리스트 IP 목록을 반환합니다.
+     * @param yaml Yaml 객체
+     * @param path YAML 파일 경로
+     * @return 화이트리스트에 포함된 IP 목록
+     * @throws IOException 파일 읽기 중 오류 발생 시
+     */
+    private List<String> parseWhitelistFile(Yaml yaml, Path path) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            Map<String, Map<String, List<String>>> data = yaml.load(inputStream);
+
+            if (CollectionUtils.isEmpty(data)) {
+                log.warn("YAML file is empty or invalid");
+                return List.of();
+            }
+
+            Map<String, List<String>> whitelist = data.getOrDefault("whitelist", Map.of());
+
+            List<String> fixedIps = whitelist.getOrDefault("fixedIps", List.of());
+            List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
+
+            return Stream.concat(
+                    fixedIps != null ? fixedIps.stream() : Stream.empty(),
+                    temporaryIps != null ? temporaryIps.stream() : Stream.empty()
+            ).toList();
+        } catch (Exception e) {
+            log.error("Failed to parse IP whitelist", e);
+            return List.of();
+        }
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/util/WhitelistPathMatcher.java
+++ b/stempo-auth/src/main/java/com/stempo/util/WhitelistPathMatcher.java
@@ -1,0 +1,53 @@
+package com.stempo.util;
+
+import com.stempo.config.WhitelistProperties;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class WhitelistPathMatcher implements InitializingBean {
+
+    private static String[] actuatorPatterns;
+    private static String[] apiDocsPatterns;
+    private static String[] whitelistPatterns;
+
+    private final WhitelistProperties whitelistProperties;
+
+    public WhitelistPathMatcher(WhitelistProperties whitelistProperties) {
+        this.whitelistProperties = whitelistProperties;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        actuatorPatterns = whitelistProperties.getPatterns().getActuator();
+        apiDocsPatterns = whitelistProperties.getPatterns().getApiDocs();
+        whitelistPatterns = whitelistProperties.getPatterns().getWhitelistPatterns();
+    }
+
+    public static boolean isApiDocsRequest(String path) {
+        return isPatternMatch(path, apiDocsPatterns);
+    }
+
+    public static boolean isActuatorRequest(String path) {
+        return isPatternMatch(path, actuatorPatterns);
+    }
+
+    public static boolean isWhitelistRequest(String path) {
+        return isPatternMatch(path, whitelistPatterns);
+    }
+
+    public static boolean isSwaggerIndexEndpoint(String path) {
+        return apiDocsPatterns[2].equals(path);
+    }
+
+    private static boolean isPatternMatch(String path, String[] patterns) {
+        for (String pattern : patterns) {
+            if (Pattern.compile(pattern).matcher(path).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/util/XssSanitizer.java
+++ b/stempo-auth/src/main/java/com/stempo/util/XssSanitizer.java
@@ -1,4 +1,4 @@
-package com.stempo.filter;
+package com.stempo.util;
 
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;

--- a/stempo-common/build.gradle.kts
+++ b/stempo-common/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
     implementation(Dependencies.swagger)
     implementation(Dependencies.gson)
     implementation(Dependencies.commonsIo)
+    implementation(Dependencies.commonText)
 }

--- a/stempo-common/build.gradle.kts
+++ b/stempo-common/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     // Spring Project
     implementation(Dependencies.springBootStarterWeb)
+    implementation(Dependencies.springBootStarterSecurity)
     implementation(Dependencies.springDataCommons)
 
     // Util

--- a/stempo-common/src/main/java/com/stempo/exception/CommonExceptionHandler.java
+++ b/stempo-common/src/main/java/com/stempo/exception/CommonExceptionHandler.java
@@ -46,9 +46,9 @@ public class CommonExceptionHandler {
             DecryptionException.class,
             DirectoryCreationException.class,
             FilePermissionException.class,
+            Exception.class
     })
     public ErrorResponse<Exception> handleServerError(HttpServletResponse response, Exception e) {
-        log.error("Server Error: {}", e.getMessage());
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         return ErrorResponse.failure(e);
     }

--- a/stempo-common/src/main/java/com/stempo/util/ApiLogger.java
+++ b/stempo-common/src/main/java/com/stempo/util/ApiLogger.java
@@ -1,0 +1,50 @@
+package com.stempo.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ApiLogger {
+
+    public static void logRequest(HttpServletRequest request, HttpServletResponse response, String clientIpAddress, String message) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
+
+        String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
+
+        String httpMethod = request.getMethod();
+        int httpStatus = response.getStatus();
+
+        log.info("[{}:{}] {} {} {} {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, message);
+    }
+
+    public static void logRequestDuration(HttpServletRequest request, HttpServletResponse response, Exception ex) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String id = (authentication == null || authentication.getName() == null) ? "anonymous" : authentication.getName();
+        String clientIpAddress = HttpReqResUtils.getClientIpAddressIfServletRequestExist();
+
+        String requestUrl = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fullUrl = queryString == null ? requestUrl : requestUrl + "?" + queryString;
+
+        String httpMethod = request.getMethod();
+        int httpStatus = response.getStatus();
+
+        long startTime = (Long) request.getAttribute("startTime");
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        if (ex == null) {
+            log.info("[{}:{}] {} {} {} {}ms", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration);
+        } else {
+            log.error("[{}:{}] {} {} {} {}ms, Exception: {}", clientIpAddress, id, fullUrl, httpMethod, httpStatus, duration, ex.getMessage());
+        }
+    }
+}

--- a/stempo-common/src/main/java/com/stempo/util/FileUtils.java
+++ b/stempo-common/src/main/java/com/stempo/util/FileUtils.java
@@ -145,7 +145,7 @@ public class FileUtils {
      * @param savePath 파일 경로
      * @throws FilePermissionException 파일 권한 설정에 실패한 경우 발생
      */
-    public static void setReadOnlyPermissionsWindows(File file, String savePath) {
+    private static void setReadOnlyPermissionsWindows(File file, String savePath) {
         if (!file.setReadOnly()) {
             throw new FilePermissionException("Failed to set file read-only: " + LogSanitizerUtils.sanitizeForLog(savePath));
         }
@@ -157,7 +157,7 @@ public class FileUtils {
      * @param filePath 파일 경로
      * @throws IOException 권한 설정 실패 시 발생
      */
-    public static void setReadOnlyPermissionsUnix(String filePath) throws IOException {
+    private static void setReadOnlyPermissionsUnix(String filePath) throws IOException {
         Path path = Paths.get(filePath);
 
         // POSIX 파일 권한을 소유자에게만 읽기 권한을 부여하도록 설정

--- a/stempo-common/src/main/java/com/stempo/util/HtmlCharacterEscapes.java
+++ b/stempo-common/src/main/java/com/stempo/util/HtmlCharacterEscapes.java
@@ -1,0 +1,40 @@
+package com.stempo.util;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
+import org.apache.commons.text.StringEscapeUtils;
+
+public class HtmlCharacterEscapes extends CharacterEscapes {
+
+    private static final char ZERO_WIDTH_JOINER = 0x200D;
+    private final int[] asciiEscapes;
+
+    public HtmlCharacterEscapes() {
+        asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
+        asciiEscapes['<'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['>'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\"'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['('] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes[')'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['#'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\''] = CharacterEscapes.ESCAPE_CUSTOM;
+    }
+
+    @Override
+    public int[] getEscapeCodesForAscii() {
+        return asciiEscapes;
+    }
+
+    @Override
+    public SerializableString getEscapeSequence(int ch) {
+        char charAt = (char) ch;
+        if (Character.isHighSurrogate(charAt) || Character.isLowSurrogate(charAt) || charAt == ZERO_WIDTH_JOINER) {
+            String sb = "\\u" +
+                    String.format("%04x", ch);
+            return new SerializedString(sb);
+        } else {
+            return new SerializedString(StringEscapeUtils.escapeHtml4(Character.toString(charAt)));
+        }
+    }
+}

--- a/stempo-domain/src/main/java/com/stempo/model/TotpAuthenticator.java
+++ b/stempo-domain/src/main/java/com/stempo/model/TotpAuthenticator.java
@@ -1,0 +1,24 @@
+package com.stempo.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TotpAuthenticator {
+
+    private String deviceTag;
+    private String secretKey;
+
+    public static TotpAuthenticator create(String memberId, String secretKey) {
+        return TotpAuthenticator.builder()
+                .deviceTag(memberId)
+                .secretKey(secretKey)
+                .build();
+    }
+}

--- a/stempo-domain/src/main/java/com/stempo/model/User.java
+++ b/stempo-domain/src/main/java/com/stempo/model/User.java
@@ -16,10 +16,25 @@ public class User {
 
     private String deviceTag;
     private String password;
+    private int failedLoginAttempts;
+    private boolean accountLocked;
     private Role role;
 
     public static User create(String deviceTag, String password) {
-        return new User(deviceTag, password, Role.USER);
+        return new User(deviceTag, password, 0, false, Role.USER);
+    }
+
+    public void incrementFailedLoginAttempts() {
+        this.failedLoginAttempts++;
+    }
+
+    public void resetFailedLoginAttempts() {
+        this.failedLoginAttempts = 0;
+        this.accountLocked = false;
+    }
+
+    public void lockAccount() {
+        this.accountLocked = true;
     }
 
     public boolean isAdmin() {

--- a/stempo-domain/src/main/java/com/stempo/repository/TotpAuthenticatorRepository.java
+++ b/stempo-domain/src/main/java/com/stempo/repository/TotpAuthenticatorRepository.java
@@ -1,0 +1,18 @@
+package com.stempo.repository;
+
+import com.stempo.model.TotpAuthenticator;
+
+import java.util.Optional;
+
+public interface TotpAuthenticatorRepository {
+
+    Optional<TotpAuthenticator> findById(String deviceTag);
+
+    TotpAuthenticator getById(String deviceTag);
+
+    boolean existsById(String deviceTag);
+
+    void delete(TotpAuthenticator authenticator);
+
+    void save(TotpAuthenticator authenticator);
+}

--- a/stempo-infrastructure/src/main/java/com/stempo/entity/TotpAuthenticatorEntity.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/entity/TotpAuthenticatorEntity.java
@@ -1,0 +1,28 @@
+package com.stempo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "totp_authenticator")
+public class TotpAuthenticatorEntity extends BaseEntity {
+
+    @Id
+    private String deviceTag;
+
+    @Column(nullable = false)
+    private String secretKey;
+}

--- a/stempo-infrastructure/src/main/java/com/stempo/entity/UserEntity.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/entity/UserEntity.java
@@ -27,6 +27,10 @@ public class UserEntity extends BaseEntity {
 
     private String password;
 
+    private int failedLoginAttempts;
+
+    private boolean accountLocked;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 }

--- a/stempo-infrastructure/src/main/java/com/stempo/exception/InfrastructureExceptionHandler.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/exception/InfrastructureExceptionHandler.java
@@ -30,7 +30,6 @@ public class InfrastructureExceptionHandler {
             Exception.class
     })
     public ErrorResponse<Exception> handleServerError(HttpServletResponse response, Exception e) {
-        log.error("Server Error: {}", e.getMessage());
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         return ErrorResponse.failure(e);
     }

--- a/stempo-infrastructure/src/main/java/com/stempo/mappper/TotpAuthenticatorMapper.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/mappper/TotpAuthenticatorMapper.java
@@ -1,0 +1,23 @@
+package com.stempo.mappper;
+
+import com.stempo.entity.TotpAuthenticatorEntity;
+import com.stempo.model.TotpAuthenticator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TotpAuthenticatorMapper {
+
+    public TotpAuthenticatorEntity toEntity(TotpAuthenticator totpAuthenticator) {
+        return TotpAuthenticatorEntity.builder()
+                .deviceTag(totpAuthenticator.getDeviceTag())
+                .secretKey(totpAuthenticator.getSecretKey())
+                .build();
+    }
+
+    public TotpAuthenticator toDomain(TotpAuthenticatorEntity entity) {
+        return TotpAuthenticator.builder()
+                .deviceTag(entity.getDeviceTag())
+                .secretKey(entity.getSecretKey())
+                .build();
+    }
+}

--- a/stempo-infrastructure/src/main/java/com/stempo/mappper/UserMapper.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/mappper/UserMapper.java
@@ -11,6 +11,8 @@ public class UserMapper {
         return UserEntity.builder()
                 .deviceTag(user.getDeviceTag())
                 .password(user.getPassword())
+                .failedLoginAttempts(user.getFailedLoginAttempts())
+                .accountLocked(user.isAccountLocked())
                 .role(user.getRole())
                 .build();
     }
@@ -19,6 +21,8 @@ public class UserMapper {
         return User.builder()
                 .deviceTag(entity.getDeviceTag())
                 .password(entity.getPassword())
+                .failedLoginAttempts(entity.getFailedLoginAttempts())
+                .accountLocked(entity.isAccountLocked())
                 .role(entity.getRole())
                 .build();
     }

--- a/stempo-infrastructure/src/main/java/com/stempo/repository/TotpAuthenticatorJpaRepository.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/repository/TotpAuthenticatorJpaRepository.java
@@ -1,0 +1,7 @@
+package com.stempo.repository;
+
+import com.stempo.entity.TotpAuthenticatorEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TotpAuthenticatorJpaRepository extends JpaRepository<TotpAuthenticatorEntity, String> {
+}

--- a/stempo-infrastructure/src/main/java/com/stempo/repository/TotpAuthenticatorRepositoryImpl.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/repository/TotpAuthenticatorRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.stempo.repository;
+
+import com.stempo.entity.TotpAuthenticatorEntity;
+import com.stempo.exception.NotFoundException;
+import com.stempo.mappper.TotpAuthenticatorMapper;
+import com.stempo.model.TotpAuthenticator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TotpAuthenticatorRepositoryImpl implements TotpAuthenticatorRepository {
+
+    private final TotpAuthenticatorJpaRepository repository;
+    private final TotpAuthenticatorMapper mapper;
+
+    @Override
+    public Optional<TotpAuthenticator> findById(String deviceTag) {
+        return repository.findById(deviceTag)
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public TotpAuthenticator getById(String deviceTag) {
+        return repository.findById(deviceTag)
+                .map(mapper::toDomain)
+                .orElseThrow(() -> new NotFoundException("[TotpAuthenticator] deviceTag: " + deviceTag + " not found"));
+    }
+
+    @Override
+    public boolean existsById(String deviceTag) {
+        return repository.existsById(deviceTag);
+    }
+
+    @Override
+    public void delete(TotpAuthenticator authenticator) {
+        TotpAuthenticatorEntity entity = mapper.toEntity(authenticator);
+        repository.delete(entity);
+    }
+
+    @Override
+    public void save(TotpAuthenticator authenticator) {
+        TotpAuthenticatorEntity entity = mapper.toEntity(authenticator);
+        repository.save(entity);
+    }
+}


### PR DESCRIPTION
## Summary

> #71 

다양한 보안 취약점 해결을 위한 작업을 수행했습니다. XSS 방어, 특정 엔드포인트에 대한 Whitelist 설정 및 Basic Auth 적용, 관리자 계정에 대한 이중 인증(TOTP) 설정, 비정상 접근 차단 로직 추가, 비밀번호 규칙 강화 등을 통해 보안을 강화했습니다.

## Tasks

- **XSS 방어**: 사용자 입력에 대해 HTML 및 자바스크립트 이스케이핑 처리 추가.
- **Whitelist 설정 및 Basic Auth 적용**: 특정 엔드포인트에 대해 허용된 IP만 접근 가능하도록 설정하고, Basic Auth 인증 적용.
- **관리자 계정 TOTP 설정**: 관리자 계정에 TOTP 이중 인증 적용.
- **비정상 접근 처리**: 비정상적인 접근에 대한 차단 로직 추가.
- **로그인 실패 횟수 제한**: 5회 로그인 실패 시 계정 잠금 및 알림 절차 추가.
- **PreAuthorize 마이그레이션**: 기존 권한 체크 로직을 `@PreAuthorize`로 마이그레이션.
- **비밀번호 규칙 적용**: KISA 권고 기준에 맞춰 비밀번호 복잡도 및 만료 주기 설정.