### PR TITLE
feat: `stempo-domain` 모듈 테스트 코드 작성 완료

### DIFF
--- a/stempo-domain/src/main/java/com/stempo/model/User.java
+++ b/stempo-domain/src/main/java/com/stempo/model/User.java
@@ -21,7 +21,13 @@ public class User {
     private Role role;
 
     public static User create(String deviceTag, String password) {
-        return new User(deviceTag, password, 0, false, Role.USER);
+        return User.builder()
+                .deviceTag(deviceTag)
+                .password(password)
+                .failedLoginAttempts(0)
+                .accountLocked(false)
+                .role(Role.USER)
+                .build();
     }
 
     public void incrementFailedLoginAttempts() {

--- a/stempo-domain/src/test/java/com/stempo/model/BoardTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/BoardTest.java
@@ -1,0 +1,114 @@
+package com.stempo.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.stempo.exception.PermissionDeniedException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BoardTest {
+
+    private Board board;
+    private User owner;
+    private User admin;
+    private User normalUser;
+
+    @BeforeEach
+    void setUp() {
+        owner = mock(User.class);
+        admin = mock(User.class);
+        normalUser = mock(User.class);
+
+        when(owner.getDeviceTag()).thenReturn("OWNER_DEVICE_TAG");
+        when(admin.getDeviceTag()).thenReturn("ADMIN_DEVICE_TAG");
+        when(admin.isAdmin()).thenReturn(true);
+        when(normalUser.getDeviceTag()).thenReturn("USER_DEVICE_TAG");
+        when(normalUser.isAdmin()).thenReturn(false);
+
+        board = Board.builder()
+                .id(1L)
+                .deviceTag("OWNER_DEVICE_TAG")
+                .category(BoardCategory.NOTICE)
+                .title("Test Title")
+                .content("Test Content")
+                .fileUrls(Arrays.asList("file1", "file2"))
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void 게시글이_정상적으로_생성되는지_확인한다() {
+        assertThat(board.getId()).isEqualTo(1L);
+        assertThat(board.getDeviceTag()).isEqualTo("OWNER_DEVICE_TAG");
+        assertThat(board.getCategory()).isEqualTo(BoardCategory.NOTICE);
+        assertThat(board.getTitle()).isEqualTo("Test Title");
+        assertThat(board.getContent()).isEqualTo("Test Content");
+        assertThat(board.getFileUrls()).containsExactly("file1", "file2");
+        assertThat(board.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void 게시글_정보를_수정할_수_있다() {
+        // given
+        Board updateBoard = Board.builder()
+                .category(BoardCategory.FAQ)
+                .title("Updated Title")
+                .content("Updated Content")
+                .fileUrls(Arrays.asList("file3", "file4"))
+                .build();
+
+        // when
+        board.update(updateBoard);
+
+        // then
+        assertThat(board.getCategory()).isEqualTo(BoardCategory.FAQ);
+        assertThat(board.getTitle()).isEqualTo("Updated Title");
+        assertThat(board.getContent()).isEqualTo("Updated Content");
+        assertThat(board.getFileUrls()).containsExactly("file3", "file4");
+    }
+
+    @Test
+    void 게시글_작성자인지_확인할_수_있다() {
+        // then
+        assertThat(board.isOwner(owner)).isTrue();
+        assertThat(board.isOwner(admin)).isFalse();
+        assertThat(board.isOwner(normalUser)).isFalse();
+    }
+
+    @Test
+    void 게시글_수정_삭제_권한을_검증한다() {
+        // 작성자 권한 검증
+        assertDoesNotThrow(() -> board.validateAccessPermission(owner));
+
+        // 관리자 권한 검증
+        assertDoesNotThrow(() -> board.validateAccessPermission(admin));
+
+        // 권한 없는 사용자 접근 시 예외 발생
+        PermissionDeniedException exception = assertThrows(PermissionDeniedException.class,
+                () -> board.validateAccessPermission(normalUser));
+        assertThat(exception.getMessage()).isEqualTo("게시글을 수정/삭제할 권한이 없습니다.");
+    }
+
+    @Test
+    void 공지사항인지_확인할_수_있다() {
+        assertThat(board.isNotice()).isTrue();
+    }
+
+    @Test
+    void 공지사항에_권한없는_사용자가_접근할_수_없다() {
+        PermissionDeniedException exception = assertThrows(PermissionDeniedException.class,
+                () -> board.validateAccessPermissionForNotice(normalUser));
+        assertThat(exception.getMessage()).isEqualTo("공지사항 관리 권한이 없습니다.");
+    }
+
+    @Test
+    void 공지사항에_관리자는_접근_가능하다() {
+        assertDoesNotThrow(() -> board.validateAccessPermissionForNotice(admin));
+    }
+}

--- a/stempo-domain/src/test/java/com/stempo/model/BoardTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/BoardTest.java
@@ -44,6 +44,7 @@ class BoardTest {
 
     @Test
     void 게시글이_정상적으로_생성되는지_확인한다() {
+        // then
         assertThat(board.getId()).isEqualTo(1L);
         assertThat(board.getDeviceTag()).isEqualTo("OWNER_DEVICE_TAG");
         assertThat(board.getCategory()).isEqualTo(BoardCategory.NOTICE);
@@ -97,12 +98,6 @@ class BoardTest {
     }
 
     @Test
-    void 작성자가_null인_경우_false를_반환한다() {
-        // then
-        assertThat(board.isOwner(null)).isFalse();
-    }
-
-    @Test
     void 게시글_수정_삭제_권한을_검증한다() {
         // 작성자 권한 검증
         assertDoesNotThrow(() -> board.validateAccessPermission(owner));
@@ -117,14 +112,8 @@ class BoardTest {
     }
 
     @Test
-    void 접근권한_검증시_user가_null인_경우_예외를_발생시킨다() {
-        PermissionDeniedException exception = assertThrows(PermissionDeniedException.class,
-                () -> board.validateAccessPermission(null));
-        assertThat(exception.getMessage()).isEqualTo("게시글을 수정/삭제할 권한이 없습니다.");
-    }
-
-    @Test
     void 공지사항인지_확인할_수_있다() {
+        // then
         assertThat(board.isNotice()).isTrue();
     }
 
@@ -139,18 +128,17 @@ class BoardTest {
 
     @Test
     void 공지사항에_권한없는_사용자가_접근할_수_없다() {
+        // when
         PermissionDeniedException exception = assertThrows(PermissionDeniedException.class,
                 () -> board.validateAccessPermissionForNotice(normalUser));
+
+        // then
         assertThat(exception.getMessage()).isEqualTo("공지사항 관리 권한이 없습니다.");
     }
 
     @Test
     void 공지사항에_관리자는_접근_가능하다() {
+        // then
         assertDoesNotThrow(() -> board.validateAccessPermissionForNotice(admin));
-    }
-
-    @Test
-    void 공지사항에_작성자가_접근할_수_있다() {
-        assertDoesNotThrow(() -> board.validateAccessPermissionForNotice(owner));
     }
 }

--- a/stempo-domain/src/test/java/com/stempo/model/BoardTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/BoardTest.java
@@ -74,11 +74,32 @@ class BoardTest {
     }
 
     @Test
+    void 게시글_정보_수정시_null_값을_무시한다() {
+        // given
+        Board updateBoard = Board.builder().build();
+
+        // when
+        board.update(updateBoard);
+
+        // then
+        assertThat(board.getCategory()).isEqualTo(BoardCategory.NOTICE);
+        assertThat(board.getTitle()).isEqualTo("Test Title");
+        assertThat(board.getContent()).isEqualTo("Test Content");
+        assertThat(board.getFileUrls()).containsExactly("file1", "file2");
+    }
+
+    @Test
     void 게시글_작성자인지_확인할_수_있다() {
         // then
         assertThat(board.isOwner(owner)).isTrue();
         assertThat(board.isOwner(admin)).isFalse();
         assertThat(board.isOwner(normalUser)).isFalse();
+    }
+
+    @Test
+    void 작성자가_null인_경우_false를_반환한다() {
+        // then
+        assertThat(board.isOwner(null)).isFalse();
     }
 
     @Test
@@ -96,8 +117,24 @@ class BoardTest {
     }
 
     @Test
+    void 접근권한_검증시_user가_null인_경우_예외를_발생시킨다() {
+        PermissionDeniedException exception = assertThrows(PermissionDeniedException.class,
+                () -> board.validateAccessPermission(null));
+        assertThat(exception.getMessage()).isEqualTo("게시글을 수정/삭제할 권한이 없습니다.");
+    }
+
+    @Test
     void 공지사항인지_확인할_수_있다() {
         assertThat(board.isNotice()).isTrue();
+    }
+
+    @Test
+    void 공지사항이_아닌경우_false를_반환한다() {
+        // when
+        board.setCategory(BoardCategory.FAQ);
+
+        // then
+        assertThat(board.isNotice()).isFalse();
     }
 
     @Test
@@ -110,5 +147,10 @@ class BoardTest {
     @Test
     void 공지사항에_관리자는_접근_가능하다() {
         assertDoesNotThrow(() -> board.validateAccessPermissionForNotice(admin));
+    }
+
+    @Test
+    void 공지사항에_작성자가_접근할_수_있다() {
+        assertDoesNotThrow(() -> board.validateAccessPermissionForNotice(owner));
     }
 }

--- a/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
@@ -37,4 +37,26 @@ class HomeworkTest {
         assertThat(homework.getDescription()).isEqualTo("UPDATED_DESCRIPTION");
         assertThat(homework.getCompleted()).isTrue();
     }
+
+    @Test
+    void 숙제_수정시_null_값을_무시한다() {
+        // given
+        Homework updateHomework = Homework.builder().build();  // 아무 값도 업데이트하지 않음
+
+        // when
+        homework.update(updateHomework);
+
+        // then
+        assertThat(homework.getDescription()).isEqualTo("DESCRIPTION");
+        assertThat(homework.getCompleted()).isFalse();
+    }
+
+    @Test
+    void 숙제의_완료_상태를_변경할_수_있다() {
+        // given
+        homework.setCompleted(true);
+
+        // then
+        assertThat(homework.getCompleted()).isTrue();
+    }
 }

--- a/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
@@ -41,7 +41,7 @@ class HomeworkTest {
     @Test
     void 숙제_수정시_null_값을_무시한다() {
         // given
-        Homework updateHomework = Homework.builder().build();  // 아무 값도 업데이트하지 않음
+        Homework updateHomework = Homework.builder().build();
 
         // when
         homework.update(updateHomework);

--- a/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
@@ -1,0 +1,40 @@
+package com.stempo.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HomeworkTest {
+
+    private Homework homework;
+
+    @BeforeEach
+    void setUp() {
+        homework = Homework.create("DEVICE_TAG", "DESCRIPTION");
+    }
+
+    @Test
+    void 숙제가_정상적으로_생성되는지_확인한다() {
+        assertThat(homework).isNotNull();
+        assertThat(homework.getDeviceTag()).isEqualTo("DEVICE_TAG");
+        assertThat(homework.getDescription()).isEqualTo("DESCRIPTION");
+        assertThat(homework.getCompleted()).isFalse();
+    }
+
+    @Test
+    void 숙제를_수정할_수_있다() {
+        // given
+        Homework updateHomework = Homework.builder()
+                .description("UPDATED_DESCRIPTION")
+                .completed(true)
+                .build();
+
+        // when
+        homework.update(updateHomework);
+
+        // then
+        assertThat(homework.getDescription()).isEqualTo("UPDATED_DESCRIPTION");
+        assertThat(homework.getCompleted()).isTrue();
+    }
+}

--- a/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/HomeworkTest.java
@@ -16,6 +16,7 @@ class HomeworkTest {
 
     @Test
     void 숙제가_정상적으로_생성되는지_확인한다() {
+        // then
         assertThat(homework).isNotNull();
         assertThat(homework.getDeviceTag()).isEqualTo("DEVICE_TAG");
         assertThat(homework.getDescription()).isEqualTo("DESCRIPTION");
@@ -41,7 +42,7 @@ class HomeworkTest {
     @Test
     void 숙제_수정시_null_값을_무시한다() {
         // given
-        Homework updateHomework = Homework.builder().build();
+        Homework updateHomework = Homework.create(null, null);
 
         // when
         homework.update(updateHomework);

--- a/stempo-domain/src/test/java/com/stempo/model/RecordTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/RecordTest.java
@@ -1,0 +1,26 @@
+package com.stempo.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecordTest {
+
+    private Record record;
+
+    @BeforeEach
+    void setUp() {
+        record = Record.create("DEVICE_TAG", "90", "150", "100");
+    }
+
+    @Test
+    void 기록이_정상적으로_생성되는지_확인한다() {
+        assertThat(record.getId()).isNull();
+        assertThat(record.getDeviceTag()).isEqualTo("DEVICE_TAG");
+        assertThat(record.getAccuracy()).isEqualTo("90");
+        assertThat(record.getDuration()).isEqualTo("150");
+        assertThat(record.getSteps()).isEqualTo("100");
+        assertThat(record.getCreatedAt()).isNull();
+    }
+}

--- a/stempo-domain/src/test/java/com/stempo/model/RecordTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/RecordTest.java
@@ -16,6 +16,7 @@ class RecordTest {
 
     @Test
     void 기록이_정상적으로_생성되는지_확인한다() {
+        // then
         assertThat(record.getId()).isNull();
         assertThat(record.getDeviceTag()).isEqualTo("DEVICE_TAG");
         assertThat(record.getAccuracy()).isEqualTo("90");

--- a/stempo-domain/src/test/java/com/stempo/model/TotpAuthenticatorTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/TotpAuthenticatorTest.java
@@ -16,6 +16,7 @@ class TotpAuthenticatorTest {
 
     @Test
     void TOTP가_정상적으로_생성되는지_확인한다() {
+        // then
         assertThat(totpAuthenticator.getDeviceTag()).isEqualTo("DEVICE_TAG");
         assertThat(totpAuthenticator.getSecretKey()).isEqualTo("SECRET_KEY");
     }

--- a/stempo-domain/src/test/java/com/stempo/model/TotpAuthenticatorTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/TotpAuthenticatorTest.java
@@ -1,0 +1,22 @@
+package com.stempo.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TotpAuthenticatorTest {
+
+    private TotpAuthenticator totpAuthenticator;
+
+    @BeforeEach
+    void setUp() {
+        totpAuthenticator = TotpAuthenticator.create("DEVICE_TAG", "SECRET_KEY");
+    }
+
+    @Test
+    void TOTP가_정상적으로_생성되는지_확인한다() {
+        assertThat(totpAuthenticator.getDeviceTag()).isEqualTo("DEVICE_TAG");
+        assertThat(totpAuthenticator.getSecretKey()).isEqualTo("SECRET_KEY");
+    }
+}

--- a/stempo-domain/src/test/java/com/stempo/model/UploadedFileTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/UploadedFileTest.java
@@ -16,6 +16,7 @@ class UploadedFileTest {
 
     @Test
     void 업로드_파일_기록이_정상적으로_생성되는지_확인한다() {
+        // then
         assertThat(uploadedFile).isNotNull();
         assertThat(uploadedFile.getId()).isNull();
         assertThat(uploadedFile.getOriginalFileName()).isEqualTo("ORIGINAL_FILE_NAME");

--- a/stempo-domain/src/test/java/com/stempo/model/UploadedFileTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/UploadedFileTest.java
@@ -1,0 +1,29 @@
+package com.stempo.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UploadedFileTest {
+
+    private UploadedFile uploadedFile;
+
+    @BeforeEach
+    void setUp() {
+        uploadedFile = UploadedFile.create("ORIGINAL_FILE_NAME", "SAVE_FILE_NAME", "SAVED_PATH", "URL", 100L);
+    }
+
+    @Test
+    void 업로드_파일_기록이_정상적으로_생성되는지_확인한다() {
+        assertThat(uploadedFile).isNotNull();
+        assertThat(uploadedFile.getId()).isNull();
+        assertThat(uploadedFile.getOriginalFileName()).isEqualTo("ORIGINAL_FILE_NAME");
+        assertThat(uploadedFile.getSaveFileName()).isEqualTo("SAVE_FILE_NAME");
+        assertThat(uploadedFile.getSavedPath()).isEqualTo("SAVED_PATH");
+        assertThat(uploadedFile.getUrl()).isEqualTo("URL");
+        assertThat(uploadedFile.getFileSize()).isEqualTo(100L);
+        assertThat(uploadedFile.getCreatedAt()).isNull();
+    }
+
+}

--- a/stempo-domain/src/test/java/com/stempo/model/UserTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/UserTest.java
@@ -80,9 +80,15 @@ class UserTest {
 
     @Test
     void 일반_사용자는_관리자가_아니다() {
-        // when
+        // given
         user.setRole(Role.USER);
 
+        // then
+        assertThat(user.isAdmin()).isFalse();
+    }
+
+    @Test
+    void 기본적으로_관리자가_아닌_사용자는_false_를_반환한다() {
         // then
         assertThat(user.isAdmin()).isFalse();
     }

--- a/stempo-domain/src/test/java/com/stempo/model/UserTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/UserTest.java
@@ -16,6 +16,7 @@ class UserTest {
 
     @Test
     void 사용자가_정상적으로_생성되는지_확인한다() {
+        // then
         assertThat(user).isNotNull();
         assertThat(user.getDeviceTag()).isEqualTo("DEVICE_TAG");
         assertThat(user.getPassword()).isEqualTo("PASSWORD");

--- a/stempo-domain/src/test/java/com/stempo/model/UserTest.java
+++ b/stempo-domain/src/test/java/com/stempo/model/UserTest.java
@@ -1,0 +1,89 @@
+package com.stempo.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.create("DEVICE_TAG", "PASSWORD");
+    }
+
+    @Test
+    void 사용자가_정상적으로_생성되는지_확인한다() {
+        assertThat(user).isNotNull();
+        assertThat(user.getDeviceTag()).isEqualTo("DEVICE_TAG");
+        assertThat(user.getPassword()).isEqualTo("PASSWORD");
+        assertThat(user.getFailedLoginAttempts()).isEqualTo(0);
+        assertThat(user.isAccountLocked()).isFalse();
+        assertThat(user.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    void 로그인_실패_횟수를_증가시킬_수_있다() {
+        // when
+        user.incrementFailedLoginAttempts();
+        user.incrementFailedLoginAttempts();
+
+        // then
+        assertThat(user.getFailedLoginAttempts()).isEqualTo(2);
+    }
+
+    @Test
+    void 로그인_실패_횟수를_초기화할_수_있다() {
+        // given
+        user.incrementFailedLoginAttempts();
+        user.incrementFailedLoginAttempts();
+
+        // when
+        user.resetFailedLoginAttempts();
+
+        // then
+        assertThat(user.getFailedLoginAttempts()).isEqualTo(0);
+        assertThat(user.isAccountLocked()).isFalse();
+    }
+
+    @Test
+    void 계정을_잠글_수_있다() {
+        // when
+        user.lockAccount();
+
+        // then
+        assertThat(user.isAccountLocked()).isTrue();
+    }
+
+    @Test
+    void 계정_잠금을_해제할_수_있다() {
+        // given
+        user.lockAccount();
+
+        // when
+        user.resetFailedLoginAttempts();
+
+        // then
+        assertThat(user.isAccountLocked()).isFalse();
+    }
+
+    @Test
+    void 관리자_계정인지_확인할_수_있다() {
+        // given
+        user.setRole(Role.ADMIN);
+
+        // then
+        assertThat(user.isAdmin()).isTrue();
+    }
+
+    @Test
+    void 일반_사용자는_관리자가_아니다() {
+        // when
+        user.setRole(Role.USER);
+
+        // then
+        assertThat(user.isAdmin()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

> #74 

`stempo-domain` 모듈 내 도메인 객체의 핵심 비즈니스 로직을 단위 테스트하여, 도메인 계층의 안정성을 검증했습니다. 테스트를 통해 데이터 무결성, 비즈니스 로직 준수 여부를 확인할 수 있도록 하였습니다.

## Tasks

- `Board` 도메인 객체 단위 테스트 추가
- `Homework` 도메인 객체 단위 테스트 추가
- `Record` 도메인 객체 단위 테스트 추가
- `TotpAuthenticator` 도메인 객체 단위 테스트 추가
 - `User` 도메인 객체 단위 테스트 추가
