### PR TITLE
feat: `stempo-auth` 모듈 테스트 코드 작성 완료

### DIFF
--- a/.github/workflows/spring-boot-gradle-ci.yml
+++ b/.github/workflows/spring-boot-gradle-ci.yml
@@ -39,6 +39,15 @@ jobs:
           mkdir -p $INFRA_TEST_DIR
           echo $INFRA_TEST_YML | base64 --decode > $INFRA_TEST_DIR/$INFRA_DIR_FILE_NAME
 
+      - name: Create application-test.yml from secret for stempo-auth
+        env:
+          AUTH_TEST_YML: ${{ secrets.AUTH_TEST_YML }}
+          AUTH_TEST_DIR: ./stempo-auth/src/test/resources
+          AUTH_DIR_FILE_NAME: application-test.yml
+        run: |
+          mkdir -p $AUTH_TEST_DIR
+          echo $AUTH_TEST_YML | base64 --decode > $AUTH_TEST_DIR/$AUTH_DIR_FILE_NAME
+
       - name: Run tests with Gradle
         run: ./gradlew test -Dspring.profiles.active=test --info
 

--- a/stempo-auth/src/main/java/com/stempo/application/JwtTokenGenerator.java
+++ b/stempo-auth/src/main/java/com/stempo/application/JwtTokenGenerator.java
@@ -36,7 +36,9 @@ public class JwtTokenGenerator {
         Collection<? extends GrantedAuthority> authorities = principal.getAuthorities();
 
         String id = principal.getUsername();
-        Role role = Role.valueOf(authorities.stream().findFirst().isPresent() ? authorities.stream().findFirst().get().getAuthority() : "ROLE_USER");
+        Role role = Role.valueOf(
+                authorities.stream().findFirst().isPresent() ? authorities.stream().findFirst().get().getAuthority()
+                        : Role.USER.name());
         return generateToken(id, role);
     }
 
@@ -45,7 +47,7 @@ public class JwtTokenGenerator {
         Date accessTokenExpiry = new Date(expiry.getTime() + (accessTokenDuration));
         String accessToken = Jwts.builder()
                 .subject(id)
-                .claim("role", role)
+                .claim("role", role == null ? Role.USER.name() : role.name())
                 .issuedAt(expiry)
                 .expiration(accessTokenExpiry)
                 .signWith(key)
@@ -54,7 +56,7 @@ public class JwtTokenGenerator {
         Date refreshTokenExpiry = new Date(expiry.getTime() + (refreshTokenDuration));
         String refreshToken = Jwts.builder()
                 .subject(id)
-                .claim("role", role)
+                .claim("role", role == null ? Role.USER.name() : role.name())
                 .issuedAt(expiry)
                 .expiration(refreshTokenExpiry)
                 .signWith(key)

--- a/stempo-auth/src/main/java/com/stempo/application/JwtTokenParser.java
+++ b/stempo-auth/src/main/java/com/stempo/application/JwtTokenParser.java
@@ -7,6 +7,9 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,10 +20,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
 
 @Component
 public class JwtTokenParser {
@@ -66,7 +65,9 @@ public class JwtTokenParser {
                     .parseSignedClaims(token)
                     .getPayload();
         } catch (ExpiredJwtException e) {
-            return e.getClaims();
+            throw new TokenValidateException("만료된 토큰입니다.");
+        } catch (Exception e) {
+            throw new TokenValidateException("유효하지 않은 토큰입니다.");
         }
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/config/CustomAuthenticationProvider.java
+++ b/stempo-auth/src/main/java/com/stempo/config/CustomAuthenticationProvider.java
@@ -26,6 +26,11 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
         UserDetails user = userDetailsService.loadUserByUsername(deviceTag);
 
+        // 사용자 정보가 없을 경우 예외 발생
+        if (user == null) {
+            throw new BadCredentialsException("자격 증명에 실패하였습니다.");
+        }
+
         // 비밀번호가 없는 계정인 경우 비밀번호를 확인하지 않고 로그인 처리
         if (user.getPassword() == null || user.getPassword().isEmpty()) {
             return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());

--- a/stempo-auth/src/main/java/com/stempo/config/WhitelistProperties.java
+++ b/stempo-auth/src/main/java/com/stempo/config/WhitelistProperties.java
@@ -31,8 +31,8 @@ public class WhitelistProperties {
     @Getter
     @Setter
     public static class Patterns {
-        private String[] actuator;
-        private String[] apiDocs;
+        private String[] actuator = new String[0];
+        private String[] apiDocs = new String[0];
 
         public String[] getWhitelistPatterns() {
             return Stream.of(apiDocs, actuator)

--- a/stempo-auth/src/main/java/com/stempo/config/YamlConfig.java
+++ b/stempo-auth/src/main/java/com/stempo/config/YamlConfig.java
@@ -9,11 +9,16 @@ import org.yaml.snakeyaml.Yaml;
 public class YamlConfig {
 
     @Bean
-    public Yaml yamlParser() {
+    public Yaml yamlParser(DumperOptions dumperOptions) {
+        return new Yaml(dumperOptions);
+    }
+
+    @Bean
+    public DumperOptions dumperOptions() {
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setIndent(2);
         options.setPrettyFlow(true);
-        return new Yaml(options);
+        return options;
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/exception/AuthExceptionHandler.java
+++ b/stempo-auth/src/main/java/com/stempo/exception/AuthExceptionHandler.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.servlet.http.HttpServletResponse;
+import java.nio.file.AccessDeniedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AuthorizationServiceException;
@@ -15,15 +16,14 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.nio.file.AccessDeniedException;
-
 @RestControllerAdvice(basePackages = "com.stempo")
 @RequiredArgsConstructor
 @Slf4j
 public class AuthExceptionHandler {
 
     @ExceptionHandler({
-            AuthenticationInfoNotFoundException.class,
+            InvalidPrincipalException.class,
+            AuthenticationNotFoundException.class,
             AuthorizationDeniedException.class,
             AuthorizationServiceException.class,
             BadCredentialsException.class,

--- a/stempo-auth/src/main/java/com/stempo/exception/AuthenticationNotFoundException.java
+++ b/stempo-auth/src/main/java/com/stempo/exception/AuthenticationNotFoundException.java
@@ -1,14 +1,14 @@
 package com.stempo.exception;
 
-public class AuthenticationInfoNotFoundException extends RuntimeException {
+public class AuthenticationNotFoundException extends RuntimeException {
 
     private static final String DEFAULT_MESSAGE = "인증 정보가 존재하지 않습니다.";
 
-    public AuthenticationInfoNotFoundException() {
+    public AuthenticationNotFoundException() {
         super(DEFAULT_MESSAGE);
     }
 
-    public AuthenticationInfoNotFoundException(String s) {
+    public AuthenticationNotFoundException(String s) {
         super(s);
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/exception/InvalidPrincipalException.java
+++ b/stempo-auth/src/main/java/com/stempo/exception/InvalidPrincipalException.java
@@ -1,0 +1,14 @@
+package com.stempo.exception;
+
+public class InvalidPrincipalException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "인증 정보가 유효하지 않습니다.";
+
+    public InvalidPrincipalException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public InvalidPrincipalException(String s) {
+        super(s);
+    }
+}

--- a/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletFilter.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletFilter.java
@@ -8,10 +8,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -20,9 +19,11 @@ public class XssEscapeServletFilter implements Filter {
     private final XssSanitizer xssSanitizer;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
         if (request instanceof HttpServletRequest) {
-            HttpServletRequest sanitizedRequest = new XssEscapeServletRequestWrapper((HttpServletRequest) request, xssSanitizer);
+            HttpServletRequest sanitizedRequest = new XssEscapeServletRequestWrapper((HttpServletRequest) request,
+                    xssSanitizer);
             chain.doFilter(sanitizedRequest, response);
         } else {
             chain.doFilter(request, response);

--- a/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletRequestWrapper.java
+++ b/stempo-auth/src/main/java/com/stempo/filter/XssEscapeServletRequestWrapper.java
@@ -3,7 +3,6 @@ package com.stempo.filter;
 import com.stempo.util.XssSanitizer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/stempo-auth/src/main/java/com/stempo/util/AuthUtils.java
+++ b/stempo-auth/src/main/java/com/stempo/util/AuthUtils.java
@@ -1,6 +1,7 @@
 package com.stempo.util;
 
-import com.stempo.exception.AuthenticationInfoNotFoundException;
+import com.stempo.exception.AuthenticationNotFoundException;
+import com.stempo.exception.InvalidPrincipalException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -8,18 +9,28 @@ import org.springframework.security.core.userdetails.User;
 public class AuthUtils {
 
     public static User getAuthenticationInfo() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || authentication.getName() == null) {
-            throw new AuthenticationInfoNotFoundException();
-        }
-        if (authentication.getPrincipal() instanceof User) {
-            return (User) authentication.getPrincipal();
+        Authentication authentication = getAuthentication();
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof User) {
+            return (User) principal;
         } else {
-            throw new AuthenticationInfoNotFoundException("인증 정보가 존재하지 않습니다.");
+            throw new InvalidPrincipalException("인증 정보가 유효하지 않습니다. Principal이 User 타입이 아닙니다.");
         }
     }
 
     public static String getAuthenticationInfoDeviceTag() {
         return getAuthenticationInfo().getUsername();
+    }
+
+    private static Authentication getAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new AuthenticationNotFoundException("SecurityContext에서 인증 정보를 찾을 수 없습니다.");
+        }
+        if (authentication.getName() == null) {
+            throw new AuthenticationNotFoundException("인증된 사용자의 이름이 없습니다.");
+        }
+        return authentication;
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/util/IpWhitelistValidator.java
+++ b/stempo-auth/src/main/java/com/stempo/util/IpWhitelistValidator.java
@@ -1,22 +1,27 @@
 package com.stempo.util;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Objects;
-
 @Component
-@RequiredArgsConstructor
 public class IpWhitelistValidator {
 
-    @Value("${security.whitelist.enabled}")
-    private boolean whitelistEnabled;
+    private final boolean whitelistEnabled;
     private final WhitelistFileLoader whitelistFileLoader;
+
+    protected IpWhitelistValidator(
+            @Value("${security.whitelist.enabled}") boolean whitelistEnabled,
+            WhitelistFileLoader whitelistFileLoader
+    ) {
+        this.whitelistEnabled = whitelistEnabled;
+        this.whitelistFileLoader = whitelistFileLoader;
+    }
 
     /**
      * 요청된 IP가 화이트리스트에 포함되는지 확인합니다.
+     *
      * @param ipAddress 확인하려는 IP 주소
      * @return IP가 화이트리스트에 포함되면 true, 그렇지 않으면 false
      */

--- a/stempo-auth/src/main/java/com/stempo/util/PasswordValidator.java
+++ b/stempo-auth/src/main/java/com/stempo/util/PasswordValidator.java
@@ -1,35 +1,47 @@
 package com.stempo.util;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class PasswordValidator {
 
-    // 최소 8자리 이상, 최대 16자리 이하
-    private static final String LENGTH_PATTERN = "^.{8,16}$";
+    // 비밀번호 길이: 최소 8자리 이상, 최대 16자리 이하
+    private static final String PASSWORD_LENGTH_PATTERN = "^.{8,16}$";
 
-    // 영문 대소문자, 숫자, 특수문자 중 3가지 이상 포함
-    private static final String CHARACTER_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[@#$%^&+=!]).{8,16}$";
+    // 비밀번호에 영문 대문자, 소문자, 숫자, 특수문자 중 최소 3가지가 포함되어야 함
+    private static final String CHARACTER_COMPLEXITY_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[@#$%^&+=!]).{8,16}$";
 
-    // 연속된 숫자나 동일한 문자 3개 이상 금지
-    private static final String SEQUENTIAL_PATTERN = "(\\w)\\1\\1";
+    // 연속된 문자나 숫자 3개 이상 금지
+    private static final String SEQUENTIAL_CHARACTERS_PATTERN = "(.)\\1\\1";
+
+    // 비밀번호에 사용자 아이디의 4자 이상 연속된 부분 문자열이 포함되면 안됨
+    private static final int MIN_USERNAME_SUBSTRING_LENGTH = 4;
 
     private final Pattern lengthPattern;
-    private final Pattern characterPattern;
+    private final Pattern complexityPattern;
     private final Pattern sequentialPattern;
 
     public PasswordValidator() {
-        this.lengthPattern = Pattern.compile(LENGTH_PATTERN);
-        this.characterPattern = Pattern.compile(CHARACTER_PATTERN);
-        this.sequentialPattern = Pattern.compile(SEQUENTIAL_PATTERN);
+        this.lengthPattern = Pattern.compile(PASSWORD_LENGTH_PATTERN);
+        this.complexityPattern = Pattern.compile(CHARACTER_COMPLEXITY_PATTERN);
+        this.sequentialPattern = Pattern.compile(SEQUENTIAL_CHARACTERS_PATTERN);
     }
 
+    /**
+     * 비밀번호가 유효한지 확인하는 메서드
+     *
+     * @param password 비밀번호
+     * @param username 사용자 아이디 (비밀번호와 비교)
+     * @return 비밀번호가 유효하면 true, 그렇지 않으면 false
+     */
     public boolean isValid(String password, String username) {
-        // 비밀번호가 null인 경우는 유효성 검사를 통과
+        // 비밀번호가 null인 경우 유효성 검사 통과
         if (password == null) {
             return true;
         }
 
-        // 비밀번호에 공백이 포함되어 있는지 확인
+        // 비밀번호에 공백이 포함되어 있는 경우 무효
         if (password.contains(" ")) {
             return false;
         }
@@ -39,21 +51,40 @@ public class PasswordValidator {
             return false;
         }
 
-        // 영문 대소문자, 숫자, 특수문자 중 3가지 이상 포함 여부 확인
-        if (!characterPattern.matcher(password).matches()) {
+        // 비밀번호 복잡도 확인 (대문자, 소문자, 숫자, 특수문자 중 3가지 이상 포함)
+        if (!complexityPattern.matcher(password).matches()) {
             return false;
         }
 
-        // 연속된 숫자나 동일한 문자 3개 이상 확인
+        // 동일한 문자나 숫자가 3번 이상 연속되는지 확인
         if (sequentialPattern.matcher(password).find()) {
             return false;
         }
 
-        // 비밀번호에 username(아이디)와 4자 이상 동일한 문자 포함 여부 확인
-        if (username != null && password.contains(username)) {
+        // 비밀번호에 username의 4자 이상 연속으로 포함된 경우 무효
+        return username == null || !containsSubstringOfLength(password, username, MIN_USERNAME_SUBSTRING_LENGTH);
+    }
+
+    /**
+     * 비밀번호에 사용자 아이디의 length 길이 이상 연속된 부분 문자열이 포함되어 있는지 확인하는 메서드
+     */
+    private boolean containsSubstringOfLength(String password, String username, int length) {
+        int usernameLength = username.length();
+        if (usernameLength < length) {
             return false;
         }
 
-        return true;
+        Set<String> substrings = new HashSet<>();
+        for (int i = 0; i <= usernameLength - length; i++) {
+            substrings.add(username.substring(i, i + length));
+        }
+
+        for (String substring : substrings) {
+            if (password.contains(substring)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/util/WhitelistFileLoader.java
+++ b/stempo-auth/src/main/java/com/stempo/util/WhitelistFileLoader.java
@@ -1,12 +1,5 @@
 package com.stempo.util;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -14,23 +7,35 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.yaml.snakeyaml.Yaml;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class WhitelistFileLoader {
 
     private final Yaml yaml;
+    private final String whitelistPath;
     private final Lock fileLock = new ReentrantLock();
 
-    @Value("${security.whitelist.path}")
-    private String whitelistPath;
+    protected WhitelistFileLoader(
+            Yaml yaml,
+            @Value("${security.whitelist.path}") String whitelistPath
+    ) {
+        this.yaml = yaml;
+        this.whitelistPath = whitelistPath;
+    }
 
     /**
      * 화이트리스트 YAML 파일에서 IP 목록을 로드합니다.
+     *
      * @return 화이트리스트에 포함된 IP 목록
      */
     public List<String> loadWhitelistIps() {
@@ -39,7 +44,7 @@ public class WhitelistFileLoader {
             Path path = Paths.get(whitelistPath);
 
             if (Files.notExists(path)) {
-                createDefaultWhitelistFile(path, yaml);
+                createDefaultWhitelistFileIfNotExist(path, yaml);
             }
 
             return parseWhitelistFile(yaml, path);
@@ -52,17 +57,18 @@ public class WhitelistFileLoader {
     }
 
     /**
-     * 기본 화이트리스트 YAML 파일을 생성합니다.
+     * 기본 화이트리스트 YAML 파일을 생성합니다. 파일이 존재하지 않을 경우에만 생성합니다.
+     *
      * @param path 파일 경로
      * @param yaml Yaml 객체
      * @throws IOException 파일 생성 중 오류 발생 시
      */
-    private void createDefaultWhitelistFile(Path path, Yaml yaml) throws IOException {
+    private void createDefaultWhitelistFileIfNotExist(Path path, Yaml yaml) throws IOException {
         Files.createDirectories(path.getParent());
         Map<String, Map<String, List<String>>> defaultContent = Map.of(
                 "whitelist", Map.of(
                         "fixedIps", List.of(""),
-                        "temporaryIps", List.of("*")
+                        "temporaryIps", List.of("*") // 모든 IP 허용
                 )
         );
         yaml.dump(defaultContent, Files.newBufferedWriter(path));
@@ -71,6 +77,7 @@ public class WhitelistFileLoader {
 
     /**
      * YAML 파일을 파싱하여 화이트리스트 IP 목록을 반환합니다.
+     *
      * @param yaml Yaml 객체
      * @param path YAML 파일 경로
      * @return 화이트리스트에 포함된 IP 목록
@@ -91,9 +98,11 @@ public class WhitelistFileLoader {
             List<String> temporaryIps = whitelist.getOrDefault("temporaryIps", List.of());
 
             return Stream.concat(
-                    fixedIps != null ? fixedIps.stream() : Stream.empty(),
-                    temporaryIps != null ? temporaryIps.stream() : Stream.empty()
-            ).toList();
+                            fixedIps.stream(),
+                            temporaryIps.stream()
+                    ).filter(Objects::nonNull)  // null 값 필터링
+                    .filter(ip -> !ip.isBlank())  // 빈 문자열 필터링
+                    .toList();
         } catch (Exception e) {
             log.error("Failed to parse IP whitelist", e);
             return List.of();

--- a/stempo-auth/src/main/java/com/stempo/util/WhitelistPathMatcher.java
+++ b/stempo-auth/src/main/java/com/stempo/util/WhitelistPathMatcher.java
@@ -1,10 +1,9 @@
 package com.stempo.util;
 
 import com.stempo.config.WhitelistProperties;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
-
-import java.util.regex.Pattern;
 
 @Component
 public class WhitelistPathMatcher implements InitializingBean {
@@ -17,13 +16,6 @@ public class WhitelistPathMatcher implements InitializingBean {
 
     public WhitelistPathMatcher(WhitelistProperties whitelistProperties) {
         this.whitelistProperties = whitelistProperties;
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        actuatorPatterns = whitelistProperties.getPatterns().getActuator();
-        apiDocsPatterns = whitelistProperties.getPatterns().getApiDocs();
-        whitelistPatterns = whitelistProperties.getPatterns().getWhitelistPatterns();
     }
 
     public static boolean isApiDocsRequest(String path) {
@@ -43,11 +35,22 @@ public class WhitelistPathMatcher implements InitializingBean {
     }
 
     protected static boolean isPatternMatch(String path, String[] patterns) {
+        if (patterns == null) {
+            return false;
+        }
+
         for (String pattern : patterns) {
             if (Pattern.compile(pattern).matcher(path).find()) {
                 return true;
             }
         }
         return false;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        actuatorPatterns = whitelistProperties.getPatterns().getActuator();
+        apiDocsPatterns = whitelistProperties.getPatterns().getApiDocs();
+        whitelistPatterns = whitelistProperties.getPatterns().getWhitelistPatterns();
     }
 }

--- a/stempo-auth/src/main/java/com/stempo/util/WhitelistPathMatcher.java
+++ b/stempo-auth/src/main/java/com/stempo/util/WhitelistPathMatcher.java
@@ -38,11 +38,11 @@ public class WhitelistPathMatcher implements InitializingBean {
         return isPatternMatch(path, whitelistPatterns);
     }
 
-    public static boolean isSwaggerIndexEndpoint(String path) {
+    public static boolean isApiDocsIndexEndpoint(String path) {
         return apiDocsPatterns[2].equals(path);
     }
 
-    private static boolean isPatternMatch(String path, String[] patterns) {
+    protected static boolean isPatternMatch(String path, String[] patterns) {
         for (String pattern : patterns) {
             if (Pattern.compile(pattern).matcher(path).find()) {
                 return true;

--- a/stempo-auth/src/test/java/com/stempo/application/CustomUserDetailsServiceTest.java
+++ b/stempo-auth/src/test/java/com/stempo/application/CustomUserDetailsServiceTest.java
@@ -1,0 +1,67 @@
+package com.stempo.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.stempo.model.CustomUserDetails;
+import com.stempo.model.Role;
+import com.stempo.model.User;
+import com.stempo.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+class CustomUserDetailsServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CustomUserDetailsService customUserDetailsService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void 유저가_정상적으로_로드되는지_확인한다() {
+        // given
+        String deviceTag = "deviceTag123";
+        User user = User.create(deviceTag, "password123");
+        when(userRepository.findById(deviceTag)).thenReturn(Optional.of(user));
+
+        // when
+        CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(deviceTag);
+
+        // then
+        assertNotNull(userDetails);
+        assertEquals(deviceTag, userDetails.getUsername());
+        assertEquals("password123", userDetails.getPassword());
+        assertTrue(userDetails.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals(Role.USER.name())));
+        verify(userRepository, times(1)).findById(deviceTag);
+    }
+
+    @Test
+    void 존재하지_않는_유저일_경우_예외를_던진다() {
+        // given
+        String deviceTag = "nonExistentDeviceTag";
+        when(userRepository.findById(deviceTag)).thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(deviceTag))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessage("[User] id: " + deviceTag + " not found");
+
+        verify(userRepository, times(1)).findById(deviceTag);
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/application/JwtTokenGeneratorTest.java
+++ b/stempo-auth/src/test/java/com/stempo/application/JwtTokenGeneratorTest.java
@@ -1,0 +1,73 @@
+package com.stempo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.stempo.dto.TokenInfo;
+import com.stempo.model.Role;
+import io.jsonwebtoken.Claims;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+class JwtTokenGeneratorTest {
+
+    private final long accessTokenDuration = 60000L; // 1분
+    private final long refreshTokenDuration = 120000L; // 2분
+
+    private JwtTokenGenerator jwtTokenGenerator;
+    private JwtTokenParser jwtTokenParser;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private UserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        String secretKey = "supersecretkeythatmustbe32byteslong!";
+        jwtTokenGenerator = new JwtTokenGenerator(secretKey, accessTokenDuration, refreshTokenDuration);
+        jwtTokenParser = new JwtTokenParser(secretKey);
+    }
+
+    @Test
+    void 정상적으로_토큰을_생성한다() {
+        // given
+        String username = "testUser";
+        Collection<GrantedAuthority> authorities = List.of((GrantedAuthority) Role.USER::name);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn(username);
+        when(userDetails.getAuthorities()).thenReturn((Collection) authorities);
+
+        // when
+        TokenInfo tokenInfo = jwtTokenGenerator.generateToken(authentication);
+
+        // then
+        assertThat(tokenInfo).isNotNull();
+        assertThat(tokenInfo.getAccessToken()).isNotNull();
+        assertThat(tokenInfo.getRefreshToken()).isNotNull();
+
+        // 토큰의 구조 검증
+        Claims claims = jwtTokenParser.parseClaims(tokenInfo.getAccessToken());
+        assertThat(claims.getSubject()).isEqualTo(username);
+        assertThat(claims.get("role")).isEqualTo(Role.USER.name());
+        assertThat(claims.getIssuedAt()).isNotNull();
+        assertThat(claims.getExpiration().getTime())
+                .isEqualTo(claims.getIssuedAt().getTime() + accessTokenDuration);
+
+        claims = jwtTokenParser.parseClaims(tokenInfo.getRefreshToken());
+        assertThat(claims.getSubject()).isEqualTo(username);
+        assertThat(claims.get("role")).isEqualTo(Role.USER.name());
+        assertThat(claims.getIssuedAt()).isNotNull();
+        assertThat(claims.getExpiration().getTime())
+                .isEqualTo(claims.getIssuedAt().getTime() + refreshTokenDuration);
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/application/JwtTokenParserTest.java
+++ b/stempo-auth/src/test/java/com/stempo/application/JwtTokenParserTest.java
@@ -1,0 +1,156 @@
+package com.stempo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.stempo.dto.TokenInfo;
+import com.stempo.exception.TokenValidateException;
+import com.stempo.model.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+class JwtTokenParserTest {
+
+    private JwtTokenParser jwtTokenParser;
+    private JwtTokenGenerator jwtTokenGenerator;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private UserDetails userDetails;
+
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        String secretKey = "supersecretkeythatmustbe32byteslong!";
+        key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        long accessTokenDuration = 60000L; // 1분
+        long refreshTokenDuration = 120000L; // 2분
+
+        jwtTokenGenerator = new JwtTokenGenerator(secretKey, accessTokenDuration, refreshTokenDuration);
+        jwtTokenParser = new JwtTokenParser(secretKey);
+    }
+
+    @Test
+    void 토큰에서_권한이_있는_사용자를_인증한다() {
+        // given
+        String username = "testUser";
+        Collection<GrantedAuthority> authorities = List.of((GrantedAuthority) Role.USER::name);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn(username);
+        when(userDetails.getAuthorities()).thenReturn((Collection) authorities);
+
+        TokenInfo tokenInfo = jwtTokenGenerator.generateToken(authentication);
+
+        // when
+        Authentication parsedAuthentication = jwtTokenParser.getAuthentication(tokenInfo.getAccessToken());
+
+        // then
+        assertThat(parsedAuthentication).isNotNull();
+        assertThat(parsedAuthentication.getName()).isEqualTo(username);
+        assertThat(parsedAuthentication.getAuthorities()).hasSize(1);
+        assertThat(parsedAuthentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals(Role.USER.getKey()))).isTrue();
+    }
+
+    @Test
+    void 권한이_없는_토큰_인증_실패시_예외를_던진다() {
+        // given
+        String username = "testUser";
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn(username);
+        when(userDetails.getAuthorities()).thenReturn(List.of());
+
+        // JWT 토큰 생성 시 role 필드를 포함하지 않음
+        String tokenWithoutRole = Jwts.builder()
+                .subject(username)
+                .signWith(key)
+                .compact();
+
+        // when, then
+        assertThatThrownBy(() -> jwtTokenParser.getAuthentication(tokenWithoutRole))
+                .isInstanceOf(TokenValidateException.class)
+                .hasMessage("권한 정보가 없는 토큰입니다.");
+    }
+
+    @Test
+    void 요청_헤더에서_정상적으로_토큰을_추출한다() {
+        // given
+        String bearerToken = "Bearer testToken";
+        when(request.getHeader("Authorization")).thenReturn(bearerToken);
+
+        // when
+        String token = jwtTokenParser.resolveToken(request);
+
+        // then
+        assertThat(token).isEqualTo("testToken");
+    }
+
+    @Test
+    void 요청_헤더에_토큰이_없으면_null을_반환한다() {
+        // given
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        // when
+        String token = jwtTokenParser.resolveToken(request);
+
+        // then
+        assertThat(token).isNull();
+    }
+
+    @Test
+    void 정상적으로_Claims를_파싱한다() {
+        // given
+        String username = "testUser";
+        Collection<? extends GrantedAuthority> authorities = List.of(Role.USER::name);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn(username);
+        when(userDetails.getAuthorities()).thenReturn((Collection) authorities);
+
+        // JWT 토큰 생성
+        TokenInfo tokenInfo = jwtTokenGenerator.generateToken(authentication);
+
+        // when
+        Claims claims = jwtTokenParser.parseClaims(tokenInfo.getAccessToken());
+
+        // then
+        assertThat(claims.getSubject()).isEqualTo(username);
+        assertThat(claims.get("role")).isEqualTo(Role.USER.name());
+    }
+
+    @Test
+    void 만료된_토큰을_파싱하면_예외를_던진다() {
+        // given
+        String expiredToken = Jwts.builder()
+                .subject("testUser")
+                .expiration(new Date(System.currentTimeMillis() - 1000))
+                .signWith(key)
+                .compact();
+
+        // when, then
+        assertThatThrownBy(() -> jwtTokenParser.parseClaims(expiredToken))
+                .isInstanceOf(TokenValidateException.class)
+                .hasMessage("만료된 토큰입니다.");
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/application/JwtTokenServiceImplTest.java
+++ b/stempo-auth/src/test/java/com/stempo/application/JwtTokenServiceImplTest.java
@@ -1,0 +1,147 @@
+package com.stempo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.stempo.dto.TokenInfo;
+import com.stempo.model.Role;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+
+class JwtTokenServiceImplTest {
+
+    @InjectMocks
+    private JwtTokenServiceImpl jwtTokenServiceImpl;
+
+    @Mock
+    private JwtTokenGenerator tokenGenerator;
+
+    @Mock
+    private JwtTokenParser tokenParser;
+
+    @Mock
+    private JwtTokenValidator tokenValidator;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void 인증정보로_토큰을_생성한다() {
+        // given
+        TokenInfo tokenInfo = TokenInfo.create("accessToken", "refreshToken");
+        when(tokenGenerator.generateToken(authentication)).thenReturn(tokenInfo);
+
+        // when
+        TokenInfo result = jwtTokenServiceImpl.generateToken(authentication);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getAccessToken()).isEqualTo("accessToken");
+        assertThat(result.getRefreshToken()).isEqualTo("refreshToken");
+        verify(tokenGenerator, times(1)).generateToken(authentication);
+    }
+
+    @Test
+    void 아이디와_역할로_토큰을_생성한다() {
+        // given
+        String userId = "testUser";
+        Role role = Role.ADMIN;
+        TokenInfo tokenInfo = TokenInfo.create("accessToken", "refreshToken");
+        when(tokenGenerator.generateToken(userId, role)).thenReturn(tokenInfo);
+
+        // when
+        TokenInfo result = jwtTokenServiceImpl.generateToken(userId, role);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getAccessToken()).isEqualTo("accessToken");
+        assertThat(result.getRefreshToken()).isEqualTo("refreshToken");
+        verify(tokenGenerator, times(1)).generateToken(userId, role);
+    }
+
+    @Test
+    void 토큰으로_인증정보를_가져온다() {
+        // given
+        String token = "testToken";
+        when(tokenParser.getAuthentication(token)).thenReturn(authentication);
+
+        // when
+        Authentication result = jwtTokenServiceImpl.getAuthentication(token);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(tokenParser, times(1)).getAuthentication(token);
+    }
+
+    @Test
+    void 요청에서_토큰을_추출한다() {
+        // given
+        String bearerToken = "Bearer testToken";
+        when(request.getHeader("Authorization")).thenReturn(bearerToken);
+        when(tokenParser.resolveToken(request)).thenReturn("testToken");
+
+        // when
+        String result = jwtTokenServiceImpl.resolveToken(request);
+
+        // then
+        assertThat(result).isEqualTo("testToken");
+        verify(tokenParser, times(1)).resolveToken(request);
+    }
+
+    @Test
+    void 토큰을_검증한다() {
+        // given
+        String token = "testToken";
+        when(tokenValidator.validateToken(token)).thenReturn(true);
+
+        // when
+        boolean result = jwtTokenServiceImpl.validateToken(token);
+
+        // then
+        assertThat(result).isTrue();
+        verify(tokenValidator, times(1)).validateToken(token);
+    }
+
+    @Test
+    void 토큰을_조용히_검증한다() {
+        // given
+        String token = "testToken";
+        when(tokenValidator.validateTokenSilently(token)).thenReturn(true);
+
+        // when
+        boolean result = jwtTokenServiceImpl.validateTokenSilently(token);
+
+        // then
+        assertThat(result).isTrue();
+        verify(tokenValidator, times(1)).validateTokenSilently(token);
+    }
+
+    @Test
+    void 리프레시_토큰인지_확인한다() {
+        // given
+        String token = "testToken";
+        when(tokenValidator.isRefreshToken(token)).thenReturn(true);
+
+        // when
+        boolean result = jwtTokenServiceImpl.isRefreshToken(token);
+
+        // then
+        assertThat(result).isTrue();
+        verify(tokenValidator, times(1)).isRefreshToken(token);
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/application/JwtTokenValidatorTest.java
+++ b/stempo-auth/src/test/java/com/stempo/application/JwtTokenValidatorTest.java
@@ -1,0 +1,158 @@
+package com.stempo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+class JwtTokenValidatorTest {
+
+    private JwtTokenValidator jwtTokenValidator;
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        String secretKey = "supersecretkeythatmustbe32byteslong!";
+        key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        long refreshTokenDuration = 120000L; // 2분
+
+        JwtTokenParser jwtTokenParser = new JwtTokenParser(secretKey);
+        jwtTokenValidator = new JwtTokenValidator(secretKey, refreshTokenDuration, jwtTokenParser);
+    }
+
+    @Test
+    void 유효한_토큰을_검증한다() {
+        // given
+        String validToken = Jwts.builder()
+                .subject("testUser")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 60000)) // 1분 유효
+                .signWith(key)
+                .compact();
+
+        // when
+        boolean isValid = jwtTokenValidator.validateToken(validToken);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void 만료된_토큰은_검증에_실패한다() {
+        // given
+        String expiredToken = Jwts.builder()
+                .subject("testUser")
+                .issuedAt(new Date(System.currentTimeMillis() - 60000))
+                .expiration(new Date(System.currentTimeMillis() - 1000))
+                .signWith(key)
+                .compact();
+
+        // when
+        boolean isValid = jwtTokenValidator.validateToken(expiredToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 잘못된_서명을_가진_토큰은_검증에_실패한다() {
+        // given
+        Key otherKey = Keys.hmacShaKeyFor("anothersecretkeythatmustbe32byteslong!".getBytes());
+        String invalidToken = Jwts.builder()
+                .subject("testUser")
+                .signWith(otherKey)
+                .compact();
+
+        // when
+        boolean isValid = jwtTokenValidator.validateToken(invalidToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비어있는_토큰은_검증에_실패한다() {
+        // given
+        String emptyToken = "";
+
+        // when
+        boolean isValid = jwtTokenValidator.validateToken(emptyToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 유효한_리프레시_토큰을_확인한다() {
+        // given
+        String refreshToken = Jwts.builder()
+                .subject("testUser")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 120000)) // 2분 유효
+                .signWith(key)
+                .compact();
+
+        // when
+        boolean isRefreshToken = jwtTokenValidator.isRefreshToken(refreshToken);
+
+        // then
+        assertThat(isRefreshToken).isTrue();
+    }
+
+    @Test
+    void 리프레시_토큰_아닌_경우를_확인한다() {
+        // given
+        String accessToken = Jwts.builder()
+                .subject("testUser")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 60000)) // 1분 유효
+                .signWith(key)
+                .compact();
+
+        // when
+        boolean isRefreshToken = jwtTokenValidator.isRefreshToken(accessToken);
+
+        // then
+        assertThat(isRefreshToken).isFalse();
+    }
+
+    @Test
+    void validateTokenSilently_유효한_토큰을_검증한다() {
+        // given
+        String validToken = Jwts.builder()
+                .subject("testUser")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 60000)) // 1분 유효
+                .signWith(key)
+                .compact();
+
+        // when
+        boolean isValid = jwtTokenValidator.validateTokenSilently(validToken);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void validateTokenSilently_잘못된_토큰은_검증에_실패한다() {
+        // given
+        Key otherKey = Keys.hmacShaKeyFor("anothersecretkeythatmustbe32byteslong!".getBytes());
+        String invalidToken = Jwts.builder()
+                .subject("testUser")
+                .signWith(otherKey)
+                .compact();
+
+        // when
+        boolean isValid = jwtTokenValidator.validateTokenSilently(invalidToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/AuthenticationConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/AuthenticationConfigTest.java
@@ -1,0 +1,115 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.stempo.application.CustomUserDetailsService;
+import com.stempo.test.config.TestConfiguration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = {AuthenticationConfig.class, TestConfiguration.class})
+@ActiveProfiles("test")
+class AuthenticationConfigTest {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private WhitelistProperties whitelistProperties;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        String username = whitelistProperties.getAccount().getUsername();
+        String password = whitelistProperties.getAccount().getPassword();
+        String role = whitelistProperties.getAccount().getRole();
+
+        UserDetails whitelistUser = org.springframework.security.core.userdetails.User.withUsername(username)
+                .password(passwordEncoder.encode(password))
+                .roles(role)
+                .build();
+
+        when(customUserDetailsService.loadUserByUsername("testuser")).thenReturn(whitelistUser);
+    }
+
+    @Test
+    void 화이트리스트_사용자가_성공적으로_인증된다() {
+        // given
+        Authentication authRequest = new UsernamePasswordAuthenticationToken("testuser", "testpass");
+
+        // when
+        Authentication authResult = authenticationManager.authenticate(authRequest);
+
+        // then
+        assertThat(authResult.isAuthenticated()).isTrue();
+        assertThat(authResult.getName()).isEqualTo("testuser");
+    }
+
+    @Test
+    void 비밀번호가_틀린_경우_인증에_실패한다() {
+        // given
+        Authentication authRequest = new UsernamePasswordAuthenticationToken("testuser", "wrongPass");
+
+        // when, then
+        assertThatThrownBy(() -> authenticationManager.authenticate(authRequest))
+                .isInstanceOf(BadCredentialsException.class);
+    }
+
+    @Test
+    void 비밀번호가_없는_경우_인증에_실패한다() {
+        // given
+        Authentication authRequest = new UsernamePasswordAuthenticationToken("testuser", null);
+
+        // when, then
+        assertThatThrownBy(() -> authenticationManager.authenticate(authRequest))
+                .isInstanceOf(BadCredentialsException.class);
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_로그인_시도하면_실패한다() {
+        // given
+        when(customUserDetailsService.loadUserByUsername("unknownUser")).thenReturn(null);
+        Authentication authRequest = new UsernamePasswordAuthenticationToken("unknownUser", "testpass");
+
+        // when, then
+        assertThatThrownBy(() -> authenticationManager.authenticate(authRequest))
+                .isInstanceOf(BadCredentialsException.class);
+    }
+
+    @Test
+    void 사용자_권한이_없는_경우_로그인_성공하지만_권한이_없다() {
+        // given
+        UserDetails userWithoutRole = org.springframework.security.core.userdetails.User.withUsername("noroleuser")
+                .password(passwordEncoder.encode("norolepass"))
+                .authorities(List.of())
+                .build();
+
+        when(customUserDetailsService.loadUserByUsername("noroleuser")).thenReturn(userWithoutRole);
+        Authentication authRequest = new UsernamePasswordAuthenticationToken("noroleuser", "norolepass");
+
+        // when
+        Authentication authResult = authenticationManager.authenticate(authRequest);
+
+        // then
+        assertThat(authResult.isAuthenticated()).isTrue();
+        assertThat(authResult.getAuthorities()).isEmpty();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/CustomAuthenticationProviderTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/CustomAuthenticationProviderTest.java
@@ -1,0 +1,116 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class CustomAuthenticationProviderTest {
+
+    private CustomAuthenticationProvider authenticationProvider;
+    private UserDetailsService userDetailsService;
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        userDetailsService = mock(UserDetailsService.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        authenticationProvider = new CustomAuthenticationProvider(userDetailsService, passwordEncoder);
+    }
+
+    @Test
+    void 비밀번호가_없는_계정으로_인증에_성공한다() {
+        // given
+        UserDetails userDetails = User.withUsername("user")
+                .password("")
+                .authorities("ROLE_USER")
+                .build();
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken("user", null);
+
+        // when
+        Authentication result = authenticationProvider.authenticate(authentication);
+
+        // then
+        assertThat(result.isAuthenticated()).isTrue();
+        assertThat(result.getCredentials()).isNull();
+
+        List<String> resultAuthorities = result.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        List<String> expectedAuthorities = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        assertThat(resultAuthorities).isEqualTo(expectedAuthorities);
+    }
+
+    @Test
+    void 비밀번호가_있는_계정으로_인증에_성공한다() {
+        // given
+        String rawPassword = "password";
+        String encodedPassword = "$2a$10$D9Q.iI1mUB7M8oC7a9tvUeC/Ux0XlxpWxjk3nFygWVa4U6S0VV/SK";
+        UserDetails userDetails = User.withUsername("user")
+                .password(encodedPassword) // 비밀번호가 있는 계정
+                .authorities("ROLE_USER")
+                .build();
+
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
+        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken("user", rawPassword);
+
+        // when
+        Authentication result = authenticationProvider.authenticate(authentication);
+
+        // then
+        assertThat(result.isAuthenticated()).isTrue();
+        assertThat(result.getCredentials()).isEqualTo(rawPassword);
+
+        List<String> resultAuthorities = result.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        List<String> expectedAuthorities = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        assertThat(resultAuthorities).isEqualTo(expectedAuthorities);
+    }
+
+    @Test
+    void 비밀번호가_틀린_경우_BadCredentialsException이_발생한다() {
+        // given
+        String rawPassword = "wrongpassword";
+        String encodedPassword = "$2a$10$D9Q.iI1mUB7M8oC7a9tvUeC/Ux0XlxpWxjk3nFygWVa4U6S0VV/SK";
+        UserDetails userDetails = User.withUsername("user")
+                .password(encodedPassword)
+                .authorities("ROLE_USER")
+                .build();
+
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
+        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(false);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken("user", rawPassword);
+
+        // when & then
+        assertThatThrownBy(() -> authenticationProvider.authenticate(authentication))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessageContaining("자격 증명에 실패하였습니다.");
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/RoleHierarchyConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/RoleHierarchyConfigTest.java
@@ -1,0 +1,37 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@SpringBootTest(classes = RoleHierarchyConfig.class)
+class RoleHierarchyConfigTest {
+
+    @Autowired
+    private RoleHierarchy roleHierarchy;
+
+    @Test
+    void roleHierarchy_빈이_정상적으로_생성된다() {
+        // then
+        assertThat(roleHierarchy).isNotNull();
+    }
+
+    @Test
+    void roleHierarchy_설정이_정상적으로_적용된다() {
+        // given
+        SimpleGrantedAuthority adminAuthority = new SimpleGrantedAuthority("ROLE_ADMIN");
+        SimpleGrantedAuthority userAuthority = new SimpleGrantedAuthority("ROLE_USER");
+
+        // when
+        boolean isAdminHigherThanUser = roleHierarchy.getReachableGrantedAuthorities(List.of(adminAuthority))
+                .contains(userAuthority);
+
+        // then
+        assertThat(isAdminHigherThanUser).isTrue();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/ValidatorConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/ValidatorConfigTest.java
@@ -1,0 +1,21 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stempo.util.PasswordValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = ValidatorConfig.class)
+class ValidatorConfigTest {
+
+    @Autowired
+    private PasswordValidator passwordValidator;
+
+    @Test
+    void passwordValidator_빈이_정상적으로_생성된다() {
+        // then
+        assertThat(passwordValidator).isNotNull();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/WhitelistPropertiesTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/WhitelistPropertiesTest.java
@@ -1,0 +1,56 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stempo.test.config.TestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles("test")
+class WhitelistPropertiesTest {
+
+    @Autowired
+    private WhitelistProperties whitelistProperties;
+
+    @Test
+    void whitelistProperties_빈이_정상적으로_생성된다() {
+        // then
+        assertThat(whitelistProperties).isNotNull();
+    }
+
+    @Test
+    void whitelistProperties_설정값이_정상적으로_적용된다() {
+        // then
+        assertThat(whitelistProperties.isEnabled()).isTrue();
+        assertThat(whitelistProperties.getPath()).isEqualTo("/whitelist");
+
+        // Account 설정값 확인
+        WhitelistProperties.Account account = whitelistProperties.getAccount();
+        assertThat(account.getUsername()).isEqualTo("testuser");
+        assertThat(account.getPassword()).isEqualTo("testpass");
+        assertThat(account.getRole()).isEqualTo("ADMIN");
+
+        // Patterns 설정값 확인
+        WhitelistProperties.Patterns patterns = whitelistProperties.getPatterns();
+        assertThat(patterns.getActuator()).containsExactly("/actuator/health", "/actuator/info");
+        assertThat(patterns.getApiDocs()).containsExactly("/v3/api-docs", "/swagger-ui.html");
+    }
+
+    @Test
+    void patterns_화이트리스트_패턴이_정상적으로_적용된다() {
+        // when
+        String[] whitelistPatterns = whitelistProperties.getPatterns().getWhitelistPatterns();
+
+        // then
+        assertThat(whitelistPatterns).containsExactlyInAnyOrder(
+                "/actuator/health",
+                "/actuator/info",
+                "/v3/api-docs",
+                "/swagger-ui.html"
+        );
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/XssConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/XssConfigTest.java
@@ -1,0 +1,61 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.filter.XssEscapeServletFilter;
+import com.stempo.util.HtmlCharacterEscapes;
+import com.stempo.util.XssSanitizer;
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+@SpringBootTest(classes = XssConfig.class)
+@Import({ObjectMapper.class, XssSanitizer.class})
+class XssConfigTest {
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter characterEscapeConverter;
+
+    @Autowired
+    private FilterRegistrationBean<Filter> xssFilter;
+
+    @Autowired
+    private XssSanitizer xssSanitizer;
+
+    @Test
+    void characterEscapeConverter_빈이_정상적으로_생성된다() {
+        // then
+        assertThat(characterEscapeConverter).isNotNull();
+    }
+
+    @Test
+    void xssFilter_빈이_정상적으로_생성된다() {
+        // then
+        assertThat(xssFilter).isNotNull();
+        assertThat(xssFilter.getFilter()).isInstanceOf(XssEscapeServletFilter.class);
+    }
+
+    @Test
+    void characterEscapeConverter_설정이_정상적으로_적용된다() {
+        // when
+        ObjectMapper objectMapper = characterEscapeConverter.getObjectMapper();
+
+        // then
+        assertThat(objectMapper.getFactory().getCharacterEscapes()).isInstanceOf(HtmlCharacterEscapes.class);
+    }
+
+    @Test
+    void xssFilter_설정이_정상적으로_적용된다() {
+        // when
+        XssEscapeServletFilter filter = (XssEscapeServletFilter) xssFilter.getFilter();
+
+        // then
+        assertThat(filter).hasFieldOrPropertyWithValue("xssSanitizer", xssSanitizer);
+        assertThat(xssFilter.getOrder()).isEqualTo(1);
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/config/YamlConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/YamlConfigTest.java
@@ -23,6 +23,11 @@ class YamlConfigTest {
     }
 
     @Test
+    void dumperOptions_빈이_정상적으로_생성된다() {
+        assertThat(dumperOptions).isNotNull();
+    }
+
+    @Test
     void dumperOptions_설정이_정상적으로_적용된다() {
         assertThat(dumperOptions.getDefaultFlowStyle()).isEqualTo(DumperOptions.FlowStyle.BLOCK);
         assertThat(dumperOptions.getIndent()).isEqualTo(2);

--- a/stempo-auth/src/test/java/com/stempo/config/YamlConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/YamlConfigTest.java
@@ -19,16 +19,19 @@ class YamlConfigTest {
 
     @Test
     void yamlParser_빈이_정상적으로_생성된다() {
+        // then
         assertThat(yamlParser).isNotNull();
     }
 
     @Test
     void dumperOptions_빈이_정상적으로_생성된다() {
+        // then
         assertThat(dumperOptions).isNotNull();
     }
 
     @Test
     void dumperOptions_설정이_정상적으로_적용된다() {
+        // then
         assertThat(dumperOptions.getDefaultFlowStyle()).isEqualTo(DumperOptions.FlowStyle.BLOCK);
         assertThat(dumperOptions.getIndent()).isEqualTo(2);
         assertThat(dumperOptions.isPrettyFlow()).isTrue();

--- a/stempo-auth/src/test/java/com/stempo/config/YamlConfigTest.java
+++ b/stempo-auth/src/test/java/com/stempo/config/YamlConfigTest.java
@@ -1,0 +1,31 @@
+package com.stempo.config;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+@SpringBootTest(classes = YamlConfig.class)
+class YamlConfigTest {
+
+    @Autowired
+    private Yaml yamlParser;
+
+    @Autowired
+    private DumperOptions dumperOptions;
+
+    @Test
+    void yamlParser_빈이_정상적으로_생성된다() {
+        assertThat(yamlParser).isNotNull();
+    }
+
+    @Test
+    void dumperOptions_설정이_정상적으로_적용된다() {
+        assertThat(dumperOptions.getDefaultFlowStyle()).isEqualTo(DumperOptions.FlowStyle.BLOCK);
+        assertThat(dumperOptions.getIndent()).isEqualTo(2);
+        assertThat(dumperOptions.isPrettyFlow()).isTrue();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/filter/CustomBasicAuthenticationFilterTest.java
+++ b/stempo-auth/src/test/java/com/stempo/filter/CustomBasicAuthenticationFilterTest.java
@@ -1,0 +1,144 @@
+package com.stempo.filter;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.stempo.config.WhitelistProperties;
+import com.stempo.util.IpWhitelistValidator;
+import com.stempo.util.WhitelistPathMatcher;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class CustomBasicAuthenticationFilterTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private IpWhitelistValidator ipWhitelistValidator;
+
+    @Mock
+    private WhitelistProperties whitelistProperties;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private CustomBasicAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MockitoAnnotations.openMocks(this);
+
+        WhitelistProperties.Patterns patterns = new WhitelistProperties.Patterns();
+        patterns.setActuator(new String[]{"/actuator/*"});
+        patterns.setApiDocs(new String[]{"/docs/*", "/swagger/*"});
+
+        when(whitelistProperties.getPatterns()).thenReturn(patterns);
+
+        WhitelistPathMatcher whitelistPathMatcher = new WhitelistPathMatcher(whitelistProperties);
+        whitelistPathMatcher.afterPropertiesSet();
+
+        when(response.getWriter()).thenReturn(new PrintWriter(System.out));
+
+        filter = new CustomBasicAuthenticationFilter(authenticationManager, ipWhitelistValidator);
+    }
+
+    @Test
+    void 화이트리스트_경로가_아니면_다음_필터로_넘긴다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/non-whitelist-path");
+
+        // when
+        filter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void 화이트리스트_IP가_아니면_401_응답을_보낸다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/docs");
+        when(ipWhitelistValidator.isIpWhitelisted(anyString())).thenReturn(false);
+
+        // when
+        filter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void 올바른_IP와_인증정보시_다음_필터로_넘긴다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/docs");
+        when(ipWhitelistValidator.isIpWhitelisted(anyString())).thenReturn(true);
+        when(request.getHeader("Authorization")).thenReturn(
+                "Basic " + Base64.getEncoder().encodeToString("user:password".getBytes()));
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("user", "password");
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(auth);
+
+        // when
+        filter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assert authentication != null;
+        assert authentication.getName().equals("user");
+    }
+
+    @Test
+    void 잘못된_인증정보시_401_응답을_보낸다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/docs");
+        when(ipWhitelistValidator.isIpWhitelisted(anyString())).thenReturn(true);
+        when(request.getHeader("Authorization")).thenReturn(
+                "Basic " + Base64.getEncoder().encodeToString("user:wrongpassword".getBytes()));
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenThrow(new BadCredentialsException("Invalid credentials"));
+
+        // when
+        filter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void 인증헤더가_없으면_401_응답을_보낸다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/docs");
+        when(ipWhitelistValidator.isIpWhitelisted(anyString())).thenReturn(true);
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        // when
+        filter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/filter/CustomBasicAuthenticationFilterTest.java
+++ b/stempo-auth/src/test/java/com/stempo/filter/CustomBasicAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.stempo.filter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.verify;
@@ -106,8 +107,8 @@ class CustomBasicAuthenticationFilterTest {
         // then
         verify(filterChain).doFilter(request, response);
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assert authentication != null;
-        assert authentication.getName().equals("user");
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getName()).isEqualTo("user");
     }
 
     @Test

--- a/stempo-auth/src/test/java/com/stempo/filter/JwtAuthenticationFilterTest.java
+++ b/stempo-auth/src/test/java/com/stempo/filter/JwtAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.stempo.filter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -39,6 +40,7 @@ class JwtAuthenticationFilterTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         jwtAuthenticationFilter = new JwtAuthenticationFilter(tokenService);
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -81,7 +83,7 @@ class JwtAuthenticationFilterTest {
         verify(tokenService).validateTokenSilently(token);
         verify(tokenService).getAuthentication(token);
         verify(filterChain).doFilter(request, response);
-        assert SecurityContextHolder.getContext().getAuthentication().equals(authentication);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isEqualTo(authentication);
     }
 
     @Test
@@ -100,7 +102,7 @@ class JwtAuthenticationFilterTest {
         // then
         verify(tokenService).resolveToken(request);
         verify(filterChain).doFilter(request, response);
-        assert SecurityContextHolder.getContext().getAuthentication() == null;
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 
     @Test
@@ -123,6 +125,6 @@ class JwtAuthenticationFilterTest {
         verify(tokenService).resolveToken(request);
         verify(tokenService).validateTokenSilently(invalidToken);
         verify(filterChain).doFilter(request, response);
-        assert SecurityContextHolder.getContext().getAuthentication() == null;
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 }

--- a/stempo-auth/src/test/java/com/stempo/filter/JwtAuthenticationFilterTest.java
+++ b/stempo-auth/src/test/java/com/stempo/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,128 @@
+package com.stempo.filter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.stempo.application.JwtTokenService;
+import com.stempo.util.WhitelistPathMatcher;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtTokenService tokenService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        jwtAuthenticationFilter = new JwtAuthenticationFilter(tokenService);
+    }
+
+    @Test
+    void 화이트리스트_경로면_다음_필터로_넘긴다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/whitelist-path");
+
+        try (MockedStatic<WhitelistPathMatcher> mockedMatcher = mockStatic(WhitelistPathMatcher.class)) {
+            mockedMatcher.when(() -> WhitelistPathMatcher.isWhitelistRequest("/whitelist-path")).thenReturn(true);
+
+            // when
+            jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+            // then
+            verify(filterChain).doFilter(request, response);
+            verify(tokenService, never()).resolveToken(request);
+        }
+    }
+
+    @Test
+    void 토큰이_유효하면_인증정보를_설정하고_다음_필터로_넘긴다() throws Exception {
+        // given
+        String token = "validToken";
+        Authentication authentication = mock(Authentication.class);
+
+        when(request.getRequestURI()).thenReturn("/api/path");
+        when(tokenService.resolveToken(request)).thenReturn(token);
+        when(tokenService.validateTokenSilently(token)).thenReturn(true);
+        when(tokenService.getAuthentication(token)).thenReturn(authentication);
+
+        // when
+        boolean isWhitelist = WhitelistPathMatcher.isWhitelistRequest("/api/path");
+
+        if (!isWhitelist) {
+            jwtAuthenticationFilter.doFilter(request, response, filterChain);
+        }
+
+        // then
+        verify(tokenService).resolveToken(request);
+        verify(tokenService).validateTokenSilently(token);
+        verify(tokenService).getAuthentication(token);
+        verify(filterChain).doFilter(request, response);
+        assert SecurityContextHolder.getContext().getAuthentication().equals(authentication);
+    }
+
+    @Test
+    void 토큰이_없는_경우_그대로_다음_필터로_넘긴다() throws Exception {
+        // given
+        when(request.getRequestURI()).thenReturn("/api/path");
+        when(tokenService.resolveToken(request)).thenReturn(null);
+
+        // when
+        boolean isWhitelist = WhitelistPathMatcher.isWhitelistRequest("/api/path");
+
+        if (!isWhitelist) {
+            jwtAuthenticationFilter.doFilter(request, response, filterChain);
+        }
+
+        // then
+        verify(tokenService).resolveToken(request);
+        verify(filterChain).doFilter(request, response);
+        assert SecurityContextHolder.getContext().getAuthentication() == null;
+    }
+
+    @Test
+    void 토큰이_유효하지_않으면_그대로_다음_필터로_넘긴다() throws Exception {
+        // given
+        String invalidToken = "invalidToken";
+
+        when(request.getRequestURI()).thenReturn("/api/path");
+        when(tokenService.resolveToken(request)).thenReturn(invalidToken);
+        when(tokenService.validateTokenSilently(invalidToken)).thenReturn(false);
+
+        // when
+        boolean isWhitelist = WhitelistPathMatcher.isWhitelistRequest("/api/path");
+
+        if (!isWhitelist) {
+            jwtAuthenticationFilter.doFilter(request, response, filterChain);
+        }
+
+        // then
+        verify(tokenService).resolveToken(request);
+        verify(tokenService).validateTokenSilently(invalidToken);
+        verify(filterChain).doFilter(request, response);
+        assert SecurityContextHolder.getContext().getAuthentication() == null;
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/filter/XssEscapeServletFilterTest.java
+++ b/stempo-auth/src/test/java/com/stempo/filter/XssEscapeServletFilterTest.java
@@ -1,0 +1,62 @@
+package com.stempo.filter;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.stempo.util.XssSanitizer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class XssEscapeServletFilterTest {
+
+    @Mock
+    private XssSanitizer xssSanitizer;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private ServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private XssEscapeServletFilter xssEscapeServletFilter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        xssEscapeServletFilter = new XssEscapeServletFilter(xssSanitizer);
+    }
+
+    @Test
+    void Http요청이_필터를_거쳐_Xss필터가_적용된다() throws IOException, ServletException {
+        // when
+        xssEscapeServletFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(any(XssEscapeServletRequestWrapper.class), eq(response));
+    }
+
+    @Test
+    void Http요청이_아닌경우_Xss필터가_적용되지_않고_다음필터로_진행된다() throws IOException, ServletException {
+        // given
+        ServletRequest nonHttpServletRequest = mock(ServletRequest.class);
+
+        // when
+        xssEscapeServletFilter.doFilter(nonHttpServletRequest, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(eq(nonHttpServletRequest), eq(response));
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/filter/XssEscapeServletRequestWrapperTest.java
+++ b/stempo-auth/src/test/java/com/stempo/filter/XssEscapeServletRequestWrapperTest.java
@@ -1,0 +1,90 @@
+package com.stempo.filter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.stempo.util.XssSanitizer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class XssEscapeServletRequestWrapperTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private XssSanitizer xssSanitizer;
+
+    private XssEscapeServletRequestWrapper xssEscapeServletRequestWrapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        xssEscapeServletRequestWrapper = new XssEscapeServletRequestWrapper(request, xssSanitizer);
+    }
+
+    @Test
+    void 파라미터가_Xss필터링되어_반환된다() {
+        // given
+        String rawValue = "<script>alert('XSS')</script>";
+        String sanitizedValue = "alert('XSS')";
+
+        when(request.getParameter("param")).thenReturn(rawValue);
+        when(xssSanitizer.sanitize(rawValue)).thenReturn(sanitizedValue);
+
+        // when
+        String result = xssEscapeServletRequestWrapper.getParameter("param");
+
+        // then
+        assertEquals(sanitizedValue, result);
+        verify(xssSanitizer).sanitize(rawValue);
+    }
+
+    @Test
+    void 여러_파라미터가_Xss필터링되어_반환된다() {
+        // given
+        String[] rawValues = {"<script>", "<b>bold</b>"};
+        String[] sanitizedValues = {"", "bold"};
+
+        when(request.getParameterValues("param")).thenReturn(rawValues);
+        when(xssSanitizer.sanitize("<script>")).thenReturn("");
+        when(xssSanitizer.sanitize("<b>bold</b>")).thenReturn("bold");
+
+        // when
+        String[] result = xssEscapeServletRequestWrapper.getParameterValues("param");
+
+        // then
+        assertArrayEquals(sanitizedValues, result);
+        verify(xssSanitizer).sanitize("<script>");
+        verify(xssSanitizer).sanitize("<b>bold</b>");
+    }
+
+    @Test
+    void 모든_파라미터가_Xss필터링되어_맵으로_반환된다() {
+        // given
+        Map<String, String[]> rawMap = new HashMap<>();
+        rawMap.put("param1", new String[]{"<script>"});
+        rawMap.put("param2", new String[]{"<b>bold</b>"});
+
+        when(request.getParameterMap()).thenReturn(rawMap);
+        when(xssSanitizer.sanitize("<script>")).thenReturn("");
+        when(xssSanitizer.sanitize("<b>bold</b>")).thenReturn("bold");
+
+        // when
+        Map<String, String[]> result = xssEscapeServletRequestWrapper.getParameterMap();
+
+        // then
+        assertEquals(2, result.size());
+        assertArrayEquals(new String[]{""}, result.get("param1"));
+        assertArrayEquals(new String[]{"bold"}, result.get("param2"));
+        verify(xssSanitizer).sanitize("<script>");
+        verify(xssSanitizer).sanitize("<b>bold</b>");
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/test/config/TestConfiguration.java
+++ b/stempo-auth/src/test/java/com/stempo/test/config/TestConfiguration.java
@@ -1,0 +1,14 @@
+package com.stempo.test.config;
+
+import com.stempo.config.WhitelistProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@EnableConfigurationProperties
+public class TestConfiguration {
+
+    @Bean
+    public WhitelistProperties whitelistProperties() {
+        return new WhitelistProperties();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/AuthUtilsTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/AuthUtilsTest.java
@@ -1,0 +1,69 @@
+package com.stempo.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.stempo.exception.AuthenticationNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class AuthUtilsTest {
+
+    @Test
+    @WithMockUser(username = "testDeviceTag")
+    void 인증정보가_정상적으로_존재하는지_확인한다() {
+        // when
+        User result = AuthUtils.getAuthenticationInfo();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo("testDeviceTag");
+    }
+
+    @Test
+    void 인증정보가_존재하지_않으면_예외를_던진다() {
+        // SecurityContext에 인증 정보가 없는 경우
+        SecurityContextHolder.clearContext(); // 인증 정보 초기화
+
+        // when, then
+        assertThatThrownBy(AuthUtils::getAuthenticationInfo)
+                .isInstanceOf(AuthenticationNotFoundException.class)
+                .hasMessage("SecurityContext에서 인증 정보를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 인증정보에_이름이_없으면_예외를_던진다() {
+        // Given
+        SecurityContext securityContext = mock(SecurityContext.class);
+        Authentication authentication = mock(Authentication.class);
+
+        // SecurityContext에 Authentication 설정, 하지만 이름은 null로 설정
+        when(authentication.getName()).thenReturn(null);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        // When, Then
+        assertThatThrownBy(AuthUtils::getAuthenticationInfo)
+                .isInstanceOf(AuthenticationNotFoundException.class)
+                .hasMessage("인증된 사용자의 이름이 없습니다.");
+    }
+
+    @Test
+    @WithMockUser(username = "testDeviceTag")
+    void 인증정보에서_디바이스_태그를_정상적으로_가져온다() {
+        // when
+        String deviceTag = AuthUtils.getAuthenticationInfoDeviceTag();
+
+        // then
+        assertThat(deviceTag).isEqualTo("testDeviceTag");
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/AuthUtilsTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/AuthUtilsTest.java
@@ -42,7 +42,7 @@ class AuthUtilsTest {
 
     @Test
     void 인증정보에_이름이_없으면_예외를_던진다() {
-        // Given
+        // given
         SecurityContext securityContext = mock(SecurityContext.class);
         Authentication authentication = mock(Authentication.class);
 
@@ -51,7 +51,7 @@ class AuthUtilsTest {
         when(securityContext.getAuthentication()).thenReturn(authentication);
         SecurityContextHolder.setContext(securityContext);
 
-        // When, Then
+        // when, then
         assertThatThrownBy(AuthUtils::getAuthenticationInfo)
                 .isInstanceOf(AuthenticationNotFoundException.class)
                 .hasMessage("인증된 사용자의 이름이 없습니다.");

--- a/stempo-auth/src/test/java/com/stempo/util/IpAddressUtilsTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/IpAddressUtilsTest.java
@@ -8,66 +8,66 @@ class IpAddressUtilsTest {
 
     @Test
     void 주어진_IP가_서브넷_내에_있을_경우_일치하는지_확인한다() {
-        // Given
+        // given
         String ipAddress = "192.168.1.10";
         String subnet = "192.168.1.0/24";
 
-        // When
+        // when
         boolean result = IpAddressUtils.isIpInRange(ipAddress, subnet);
 
-        // Then
+        // then
         assertThat(result).isTrue();
     }
 
     @Test
     void 주어진_IP가_서브넷_내에_없을_경우_일치하지_않는지_확인한다() {
-        // Given
+        // given
         String ipAddress = "192.168.2.10";
         String subnet = "192.168.1.0/24";
 
-        // When
+        // when
         boolean result = IpAddressUtils.isIpInRange(ipAddress, subnet);
 
-        // Then
+        // then
         assertThat(result).isFalse();
     }
 
     @Test
     void 주어진_IP가_단일_IP와_일치하는지_확인한다() {
-        // Given
+        // given
         String ipAddress = "192.168.1.10";
         String singleIp = "192.168.1.10";
 
-        // When
+        // when
         boolean result = IpAddressUtils.isIpInRange(ipAddress, singleIp);
 
-        // Then
+        // then
         assertThat(result).isTrue();
     }
 
     @Test
     void 주어진_IP가_단일_IP와_일치하지_않는지_확인한다() {
-        // Given
+        // given
         String ipAddress = "192.168.1.11";
         String singleIp = "192.168.1.10";
 
-        // When
+        // when
         boolean result = IpAddressUtils.isIpInRange(ipAddress, singleIp);
 
-        // Then
+        // then
         assertThat(result).isFalse();
     }
 
     @Test
     void 잘못된_CIDR_주소가_주어졌을_경우_예외를_처리한다() {
-        // Given
+        // given
         String ipAddress = "192.168.1.10";
         String invalidCidr = "192.168.1.0/33";
 
-        // When
+        // when
         boolean result = IpAddressUtils.isIpInRange(ipAddress, invalidCidr);
 
-        // Then
+        // then
         assertThat(result).isFalse();
     }
 }

--- a/stempo-auth/src/test/java/com/stempo/util/IpAddressUtilsTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/IpAddressUtilsTest.java
@@ -1,0 +1,73 @@
+package com.stempo.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class IpAddressUtilsTest {
+
+    @Test
+    void 주어진_IP가_서브넷_내에_있을_경우_일치하는지_확인한다() {
+        // Given
+        String ipAddress = "192.168.1.10";
+        String subnet = "192.168.1.0/24";
+
+        // When
+        boolean result = IpAddressUtils.isIpInRange(ipAddress, subnet);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 주어진_IP가_서브넷_내에_없을_경우_일치하지_않는지_확인한다() {
+        // Given
+        String ipAddress = "192.168.2.10";
+        String subnet = "192.168.1.0/24";
+
+        // When
+        boolean result = IpAddressUtils.isIpInRange(ipAddress, subnet);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 주어진_IP가_단일_IP와_일치하는지_확인한다() {
+        // Given
+        String ipAddress = "192.168.1.10";
+        String singleIp = "192.168.1.10";
+
+        // When
+        boolean result = IpAddressUtils.isIpInRange(ipAddress, singleIp);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 주어진_IP가_단일_IP와_일치하지_않는지_확인한다() {
+        // Given
+        String ipAddress = "192.168.1.11";
+        String singleIp = "192.168.1.10";
+
+        // When
+        boolean result = IpAddressUtils.isIpInRange(ipAddress, singleIp);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 잘못된_CIDR_주소가_주어졌을_경우_예외를_처리한다() {
+        // Given
+        String ipAddress = "192.168.1.10";
+        String invalidCidr = "192.168.1.0/33";
+
+        // When
+        boolean result = IpAddressUtils.isIpInRange(ipAddress, invalidCidr);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/IpWhitelistValidatorTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/IpWhitelistValidatorTest.java
@@ -24,82 +24,82 @@ class IpWhitelistValidatorTest {
 
     @Test
     void 화이트리스트가_비활성화된_경우_항상_허용한다() {
-        // Given
+        // given
         ipWhitelistValidator = new IpWhitelistValidator(false, whitelistFileLoader);
 
-        // When
+        // when
         boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.1");
 
-        // Then
+        // then
         assertThat(result).isTrue();
     }
 
     @Test
     void 요청된_IP가_화이트리스트에_포함된_경우_허용한다() {
-        // Given
+        // given
         ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
         List<String> whitelistIps = Arrays.asList("192.168.1.1", "10.0.0.0/24");
         when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
 
-        // When
+        // when
         boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.1");
 
-        // Then
+        // then
         assertThat(result).isTrue();
     }
 
     @Test
     void 요청된_IP가_서브넷에_포함된_경우_허용한다() {
-        // Given
+        // given
         ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
         List<String> whitelistIps = Collections.singletonList("192.168.1.0/24");
         when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
 
-        // When
+        // when
         boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.50");
 
-        // Then
+        // then
         assertThat(result).isTrue();
     }
 
     @Test
     void 요청된_IP가_화이트리스트에_없는_경우_거부한다() {
-        // Given
+        // given
         ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
         List<String> whitelistIps = Arrays.asList("192.168.1.1", "10.0.0.0/24");
         when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
 
-        // When
+        // when
         boolean result = ipWhitelistValidator.isIpWhitelisted("172.16.0.1");
 
-        // Then
+        // then
         assertThat(result).isFalse();
     }
 
     @Test
     void 화이트리스트가_비어있는_경우_거부한다() {
-        // Given
+        // given
         ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
         when(whitelistFileLoader.loadWhitelistIps()).thenReturn(Collections.emptyList());
 
-        // When
+        // when
         boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.1");
 
-        // Then
+        // then
         assertThat(result).isFalse();
     }
 
     @Test
     void 요청된_IP가_와일드카드와_일치하면_허용한다() {
-        // Given
+        // given
         ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
         List<String> whitelistIps = Collections.singletonList("*");
         when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
 
-        // When
+        // when
         boolean result = ipWhitelistValidator.isIpWhitelisted("172.16.0.1");
 
-        // Then
+        // then
         assertThat(result).isTrue();
     }
 }

--- a/stempo-auth/src/test/java/com/stempo/util/IpWhitelistValidatorTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/IpWhitelistValidatorTest.java
@@ -1,0 +1,105 @@
+package com.stempo.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+class IpWhitelistValidatorTest {
+
+    private WhitelistFileLoader whitelistFileLoader;
+    private IpWhitelistValidator ipWhitelistValidator;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        whitelistFileLoader = mock(WhitelistFileLoader.class);
+    }
+
+    @Test
+    void 화이트리스트가_비활성화된_경우_항상_허용한다() {
+        // Given
+        ipWhitelistValidator = new IpWhitelistValidator(false, whitelistFileLoader);
+
+        // When
+        boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.1");
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 요청된_IP가_화이트리스트에_포함된_경우_허용한다() {
+        // Given
+        ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
+        List<String> whitelistIps = Arrays.asList("192.168.1.1", "10.0.0.0/24");
+        when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
+
+        // When
+        boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.1");
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 요청된_IP가_서브넷에_포함된_경우_허용한다() {
+        // Given
+        ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
+        List<String> whitelistIps = Collections.singletonList("192.168.1.0/24");
+        when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
+
+        // When
+        boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.50");
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 요청된_IP가_화이트리스트에_없는_경우_거부한다() {
+        // Given
+        ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
+        List<String> whitelistIps = Arrays.asList("192.168.1.1", "10.0.0.0/24");
+        when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
+
+        // When
+        boolean result = ipWhitelistValidator.isIpWhitelisted("172.16.0.1");
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 화이트리스트가_비어있는_경우_거부한다() {
+        // Given
+        ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
+        when(whitelistFileLoader.loadWhitelistIps()).thenReturn(Collections.emptyList());
+
+        // When
+        boolean result = ipWhitelistValidator.isIpWhitelisted("192.168.1.1");
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void 요청된_IP가_와일드카드와_일치하면_허용한다() {
+        // Given
+        ipWhitelistValidator = new IpWhitelistValidator(true, whitelistFileLoader);
+        List<String> whitelistIps = Collections.singletonList("*");
+        when(whitelistFileLoader.loadWhitelistIps()).thenReturn(whitelistIps);
+
+        // When
+        boolean result = ipWhitelistValidator.isIpWhitelisted("172.16.0.1");
+
+        // Then
+        assertThat(result).isTrue();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/PasswordValidatorTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/PasswordValidatorTest.java
@@ -16,91 +16,118 @@ class PasswordValidatorTest {
 
     @Test
     void 비밀번호가_유효한_경우() {
+        // given
         String password = "Valid123!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isTrue();
     }
 
     @Test
     void 비밀번호가_null인_경우_유효성을_통과한다() {
+        // given
         String password = null;
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isTrue();
     }
 
     @Test
     void 비밀번호에_공백이_포함된_경우() {
+        // given
         String password = "Password 123!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isFalse();
     }
 
     @Test
     void 비밀번호_길이가_짧은_경우() {
+        // given
         String password = "Abc12!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isFalse();
     }
 
     @Test
     void 비밀번호_길이가_긴_경우() {
+        // given
         String password = "VeryLongPassword123!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isFalse();
     }
 
     @Test
     void 비밀번호에_영문_대소문자_숫자_특수문자가_없는_경우() {
+        // given
         String password = "password";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isFalse();
     }
 
     @Test
     void 비밀번호에_동일한_문자가_세번_연속된_경우() {
+        // given
         String password = "Valid123!!!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isFalse();
     }
 
     @Test
     void 비밀번호에_아이디의_4자_이상_연속된_문자가_포함된_경우() {
+        // given
         String password = "user1234!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isFalse();
     }
 
     @Test
     void 비밀번호가_복잡성_요구사항을_충족하는_경우() {
+        // given
         String password = "Abcdef123!";
         String username = "user123";
 
+        // when
         boolean isValid = passwordValidator.isValid(password, username);
 
+        // then
         assertThat(isValid).isTrue();
     }
 }

--- a/stempo-auth/src/test/java/com/stempo/util/PasswordValidatorTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/PasswordValidatorTest.java
@@ -1,0 +1,106 @@
+package com.stempo.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PasswordValidatorTest {
+
+    private PasswordValidator passwordValidator;
+
+    @BeforeEach
+    void setUp() {
+        passwordValidator = new PasswordValidator();
+    }
+
+    @Test
+    void 비밀번호가_유효한_경우() {
+        String password = "Valid123!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void 비밀번호가_null인_경우_유효성을_통과한다() {
+        String password = null;
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void 비밀번호에_공백이_포함된_경우() {
+        String password = "Password 123!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비밀번호_길이가_짧은_경우() {
+        String password = "Abc12!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비밀번호_길이가_긴_경우() {
+        String password = "VeryLongPassword123!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비밀번호에_영문_대소문자_숫자_특수문자가_없는_경우() {
+        String password = "password";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비밀번호에_동일한_문자가_세번_연속된_경우() {
+        String password = "Valid123!!!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비밀번호에_아이디의_4자_이상_연속된_문자가_포함된_경우() {
+        String password = "user1234!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    void 비밀번호가_복잡성_요구사항을_충족하는_경우() {
+        String password = "Abcdef123!";
+        String username = "user123";
+
+        boolean isValid = passwordValidator.isValid(password, username);
+
+        assertThat(isValid).isTrue();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/WhitelistFileLoaderTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/WhitelistFileLoaderTest.java
@@ -1,0 +1,76 @@
+package com.stempo.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+
+class WhitelistFileLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private WhitelistFileLoader whitelistFileLoader;
+
+    @BeforeEach
+    void setUp() {
+        String whitelistPath = tempDir.resolve("whitelist.yml").toString();
+        whitelistFileLoader = new WhitelistFileLoader(new Yaml(), whitelistPath);
+    }
+
+    @Test
+    void 화이트리스트_파일이_존재하지_않으면_기본_파일을_생성한다() {
+        // when
+        List<String> result = whitelistFileLoader.loadWhitelistIps();
+
+        // then
+        assertThat(result).contains("*");
+        Path whitelistPath = tempDir.resolve("whitelist.yml");
+        assertThat(Files.exists(whitelistPath)).isTrue();
+    }
+
+    @Test
+    void 화이트리스트_파일에서_정상적으로_IP를_로드한다() throws IOException {
+        // given
+        Path whitelistPath = tempDir.resolve("whitelist.yml");
+        Files.writeString(whitelistPath, "whitelist:\n  fixedIps: [\"192.168.1.1\"]\n  temporaryIps: [\"*\"]");
+
+        // when
+        List<String> result = whitelistFileLoader.loadWhitelistIps();
+
+        // then
+        assertThat(result).containsExactly("192.168.1.1", "*");
+    }
+
+    @Test
+    void 화이트리스트_파일이_비어있으면_빈_목록을_반환한다() throws IOException {
+        // given
+        Path whitelistPath = tempDir.resolve("whitelist.yml");
+        Files.writeString(whitelistPath, "");
+
+        // when
+        List<String> result = whitelistFileLoader.loadWhitelistIps();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void YAML_파싱_실패시_빈_목록을_반환한다() throws IOException {
+        // given
+        Path whitelistPath = tempDir.resolve("whitelist.yml");
+        Files.writeString(whitelistPath, "invalid_yaml_content");
+
+        // when
+        List<String> result = whitelistFileLoader.loadWhitelistIps();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/WhitelistPathMatcherTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/WhitelistPathMatcherTest.java
@@ -1,0 +1,58 @@
+package com.stempo.util;
+
+import com.stempo.config.WhitelistProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WhitelistPathMatcherTest {
+
+    @BeforeEach
+    void setUp() {
+        WhitelistProperties whitelistProperties = Mockito.mock(WhitelistProperties.class);
+        WhitelistProperties.Patterns patterns = new WhitelistProperties.Patterns();
+        patterns.setActuator(new String[]{"/actuator/.*"});
+        patterns.setApiDocs(new String[]{"/v3/api-docs/.*", "/swagger-ui/.*", "/swagger-ui/index.html"});
+
+        Mockito.when(whitelistProperties.getPatterns()).thenReturn(patterns);
+
+        WhitelistPathMatcher whitelistPathMatcher = new WhitelistPathMatcher(whitelistProperties);
+        whitelistPathMatcher.afterPropertiesSet();
+    }
+
+    @Test
+    void ApiDocs_경로인지_확인한다() {
+        assertThat(WhitelistPathMatcher.isApiDocsRequest("/v3/api-docs/example")).isTrue();
+        assertThat(WhitelistPathMatcher.isApiDocsRequest("/swagger-ui/index.html")).isTrue();
+        assertThat(WhitelistPathMatcher.isApiDocsRequest("/non-api-docs-path")).isFalse();
+    }
+
+    @Test
+    void Actuator_경로인지_확인한다() {
+        assertThat(WhitelistPathMatcher.isActuatorRequest("/actuator/health")).isTrue();
+        assertThat(WhitelistPathMatcher.isActuatorRequest("/actuator/info")).isTrue();
+        assertThat(WhitelistPathMatcher.isActuatorRequest("/non-actuator-path")).isFalse();
+    }
+
+    @Test
+    void Whitelist_경로인지_확인한다() {
+        assertThat(WhitelistPathMatcher.isWhitelistRequest("/actuator/health")).isTrue();
+        assertThat(WhitelistPathMatcher.isWhitelistRequest("/non-whitelist-path")).isFalse();
+    }
+
+    @Test
+    void ApiDocs_Index_엔드포인트인지_확인한다() {
+        assertThat(WhitelistPathMatcher.isApiDocsIndexEndpoint("/swagger-ui/index.html")).isTrue();
+        assertThat(WhitelistPathMatcher.isApiDocsIndexEndpoint("/v3/api-docs")).isFalse();
+    }
+
+    @Test
+    void 패턴과_일치하는지_확인한다() {
+        String[] patterns = {"/test/.*", "/example/.*"};
+        assertThat(WhitelistPathMatcher.isPatternMatch("/test/path", patterns)).isTrue();
+        assertThat(WhitelistPathMatcher.isPatternMatch("/example/path", patterns)).isTrue();
+        assertThat(WhitelistPathMatcher.isPatternMatch("/non-matching-path", patterns)).isFalse();
+    }
+}

--- a/stempo-auth/src/test/java/com/stempo/util/WhitelistPathMatcherTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/WhitelistPathMatcherTest.java
@@ -1,11 +1,11 @@
 package com.stempo.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.stempo.config.WhitelistProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class WhitelistPathMatcherTest {
 
@@ -24,35 +24,65 @@ class WhitelistPathMatcherTest {
 
     @Test
     void ApiDocs_경로인지_확인한다() {
-        assertThat(WhitelistPathMatcher.isApiDocsRequest("/v3/api-docs/example")).isTrue();
-        assertThat(WhitelistPathMatcher.isApiDocsRequest("/swagger-ui/index.html")).isTrue();
-        assertThat(WhitelistPathMatcher.isApiDocsRequest("/non-api-docs-path")).isFalse();
+        // when
+        boolean result1 = WhitelistPathMatcher.isApiDocsRequest("/v3/api-docs/example");
+        boolean result2 = WhitelistPathMatcher.isApiDocsRequest("/swagger-ui/index.html");
+        boolean result3 = WhitelistPathMatcher.isApiDocsRequest("/non-api-docs-path");
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isTrue();
+        assertThat(result3).isFalse();
     }
 
     @Test
     void Actuator_경로인지_확인한다() {
-        assertThat(WhitelistPathMatcher.isActuatorRequest("/actuator/health")).isTrue();
-        assertThat(WhitelistPathMatcher.isActuatorRequest("/actuator/info")).isTrue();
-        assertThat(WhitelistPathMatcher.isActuatorRequest("/non-actuator-path")).isFalse();
+        // when
+        boolean result1 = WhitelistPathMatcher.isActuatorRequest("/actuator/health");
+        boolean result2 = WhitelistPathMatcher.isActuatorRequest("/actuator/info");
+        boolean result3 = WhitelistPathMatcher.isActuatorRequest("/non-actuator-path");
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isTrue();
+        assertThat(result3).isFalse();
     }
 
     @Test
     void Whitelist_경로인지_확인한다() {
-        assertThat(WhitelistPathMatcher.isWhitelistRequest("/actuator/health")).isTrue();
-        assertThat(WhitelistPathMatcher.isWhitelistRequest("/non-whitelist-path")).isFalse();
+        // when
+        boolean result1 = WhitelistPathMatcher.isWhitelistRequest("/actuator/health");
+        boolean result2 = WhitelistPathMatcher.isWhitelistRequest("/non-whitelist-path");
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
     }
 
     @Test
     void ApiDocs_Index_엔드포인트인지_확인한다() {
-        assertThat(WhitelistPathMatcher.isApiDocsIndexEndpoint("/swagger-ui/index.html")).isTrue();
-        assertThat(WhitelistPathMatcher.isApiDocsIndexEndpoint("/v3/api-docs")).isFalse();
+        // when
+        boolean result1 = WhitelistPathMatcher.isApiDocsIndexEndpoint("/swagger-ui/index.html");
+        boolean result2 = WhitelistPathMatcher.isApiDocsIndexEndpoint("/v3/api-docs");
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
     }
 
     @Test
     void 패턴과_일치하는지_확인한다() {
+        // given
         String[] patterns = {"/test/.*", "/example/.*"};
-        assertThat(WhitelistPathMatcher.isPatternMatch("/test/path", patterns)).isTrue();
-        assertThat(WhitelistPathMatcher.isPatternMatch("/example/path", patterns)).isTrue();
-        assertThat(WhitelistPathMatcher.isPatternMatch("/non-matching-path", patterns)).isFalse();
+
+        // when
+        boolean result1 = WhitelistPathMatcher.isPatternMatch("/test/path", patterns);
+        boolean result2 = WhitelistPathMatcher.isPatternMatch("/example/path", patterns);
+        boolean result3 = WhitelistPathMatcher.isPatternMatch("/non-matching-path", patterns);
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isTrue();
+        assertThat(result3).isFalse();
     }
 }

--- a/stempo-auth/src/test/java/com/stempo/util/XssSanitizerTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/XssSanitizerTest.java
@@ -16,58 +16,58 @@ class XssSanitizerTest {
 
     @Test
     void XSS_공격_패턴이_제거된다() {
-        // Given
+        // given
         String input = "<script>alert('XSS');</script>";
 
-        // When
+        // when
         String sanitized = xssSanitizer.sanitize(input);
 
-        // Then
+        // then
         assertThat(sanitized).isEmpty();
     }
 
     @Test
     void 허용된_링크_태그는_유지된다() {
-        // Given
+        // given
         String input = "<a href='http://example.com'>Link</a>";
 
-        // When
+        // when
         String sanitized = xssSanitizer.sanitize(input);
 
-        // Then
+        // then
         assertThat(sanitized).isEqualTo("<a href=\"http://example.com\" rel=\"nofollow\">Link</a>");
     }
 
     @Test
     void 허용된_형식_태그는_유지된다() {
-        // Given
+        // given
         String input = "<b>Bold Text</b><i>Italic Text</i>";
 
-        // When
+        // when
         String sanitized = xssSanitizer.sanitize(input);
 
-        // Then
+        // then
         assertThat(sanitized).isEqualTo("<b>Bold Text</b><i>Italic Text</i>");
     }
 
     @Test
     void 입력값이_null이면_null을_반환한다() {
-        // When
+        // when
         String sanitized = xssSanitizer.sanitize(null);
 
-        // Then
+        // then
         assertThat(sanitized).isNull();
     }
 
     @Test
     void 안전한_문자열은_변경되지_않는다() {
-        // Given
+        // given
         String input = "Safe text";
 
-        // When
+        // when
         String sanitized = xssSanitizer.sanitize(input);
 
-        // Then
+        // then
         assertThat(sanitized).isEqualTo("Safe text");
     }
 }

--- a/stempo-auth/src/test/java/com/stempo/util/XssSanitizerTest.java
+++ b/stempo-auth/src/test/java/com/stempo/util/XssSanitizerTest.java
@@ -1,0 +1,73 @@
+package com.stempo.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class XssSanitizerTest {
+
+    private XssSanitizer xssSanitizer;
+
+    @BeforeEach
+    void setUp() {
+        xssSanitizer = new XssSanitizer();
+    }
+
+    @Test
+    void XSS_공격_패턴이_제거된다() {
+        // Given
+        String input = "<script>alert('XSS');</script>";
+
+        // When
+        String sanitized = xssSanitizer.sanitize(input);
+
+        // Then
+        assertThat(sanitized).isEmpty();
+    }
+
+    @Test
+    void 허용된_링크_태그는_유지된다() {
+        // Given
+        String input = "<a href='http://example.com'>Link</a>";
+
+        // When
+        String sanitized = xssSanitizer.sanitize(input);
+
+        // Then
+        assertThat(sanitized).isEqualTo("<a href=\"http://example.com\" rel=\"nofollow\">Link</a>");
+    }
+
+    @Test
+    void 허용된_형식_태그는_유지된다() {
+        // Given
+        String input = "<b>Bold Text</b><i>Italic Text</i>";
+
+        // When
+        String sanitized = xssSanitizer.sanitize(input);
+
+        // Then
+        assertThat(sanitized).isEqualTo("<b>Bold Text</b><i>Italic Text</i>");
+    }
+
+    @Test
+    void 입력값이_null이면_null을_반환한다() {
+        // When
+        String sanitized = xssSanitizer.sanitize(null);
+
+        // Then
+        assertThat(sanitized).isNull();
+    }
+
+    @Test
+    void 안전한_문자열은_변경되지_않는다() {
+        // Given
+        String input = "Safe text";
+
+        // When
+        String sanitized = xssSanitizer.sanitize(input);
+
+        // Then
+        assertThat(sanitized).isEqualTo("Safe text");
+    }
+}


### PR DESCRIPTION
## Summary

> #79 

Spring Security 인증/인가 로직과 관련된 유닛 테스트와 통합 테스트를 추가하여, `stempo-auth` 모듈에서 JWT 발급 및 검증 로직을 포함한 보안 기능이 올바르게 동작하는지 검증했습니다.

## Tasks

- 인증/인가 관련 유닛 테스트 작성
- Spring Security 설정 검증
- 로그인 및 토큰 발급 기능 테스트
- 유틸리티 클래스 테스트

## ETC

- 테스트가 안정적으로 수행되도록 `SecurityContextHolder.clearContext()`를 각 테스트 시작 전에 호출하여 `ThreadLocal`로 인해 발생할 수 있는 테스트 간 상태 공유 문제를 해결했습니다.