### PR TITLE
feat: `WebMvcTest`를 활용한 API 컨트롤러 테스트 작성 완료

### DIFF
--- a/stempo-api/src/test/java/com/stempo/controller/AuthControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/AuthControllerTest.java
@@ -1,0 +1,352 @@
+package com.stempo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.dto.TokenInfo;
+import com.stempo.dto.request.AuthRequestDto;
+import com.stempo.dto.request.TwoFactorAuthenticationRequestDto;
+import com.stempo.exception.BaseException;
+import com.stempo.exception.ErrorCode;
+import com.stempo.service.AuthService;
+import com.stempo.test.TestApplication;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AuthController.class)
+@ContextConfiguration(classes = TestApplication.class)
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 정상적으로_회원가입을_한다() throws Exception {
+        // given
+        AuthRequestDto requestDto = new AuthRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setPassword("password123");
+
+        TokenInfo tokenInfo = TokenInfo.create("access-token", "refresh-token");
+
+        when(authService.registerUser(any(AuthRequestDto.class)))
+                .thenReturn(tokenInfo);
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    void 유효하지_않은_데이터로_회원가입을_시도하면_예외가_발생한다() throws Exception {
+        // given
+        AuthRequestDto requestDto = new AuthRequestDto();
+        requestDto.setPassword("password123");
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 이미_존재하는_사용자로_회원가입을_시도하면_예외가_발생한다() throws Exception {
+        // given
+        AuthRequestDto requestDto = new AuthRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setPassword("password123");
+
+        when(authService.registerUser(any(AuthRequestDto.class)))
+                .thenThrow(new BaseException(ErrorCode.USER_ALREADY_EXISTS, "사용자가 이미 존재합니다."));
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_회원탈퇴를_한다() throws Exception {
+        // given
+        String deviceTag = "490154203237518";
+
+        when(authService.unregisterUser())
+                .thenReturn(deviceTag);
+
+        // when
+        mockMvc.perform(delete("/api/v1/auth/unregister")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(deviceTag));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_회원탈퇴를_시도하면_권한에러가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(delete("/api/v1/auth/unregister")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 정상적으로_로그인한다() throws Exception {
+        // given
+        AuthRequestDto requestDto = new AuthRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setPassword("password123");
+
+        TokenInfo tokenInfo = TokenInfo.create("access-token", "refresh-token");
+
+        when(authService.login(any(AuthRequestDto.class)))
+                .thenReturn(tokenInfo);
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    void 잘못된_자격증명으로_로그인_시도하면_예외가_발생한다() throws Exception {
+        // given
+        AuthRequestDto requestDto = new AuthRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setPassword("wrongpassword");
+
+        when(authService.login(any(AuthRequestDto.class)))
+                .thenThrow(new BaseException(ErrorCode.BAD_CREDENTIALS, "잘못된 자격 증명입니다."));
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_로그인을_시도한다() throws Exception {
+        // given
+        AuthRequestDto requestDto = new AuthRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setPassword("password123");
+
+        TokenInfo tokenInfo = TokenInfo.create("access-token", "refresh-token");
+
+        when(authService.login(any(AuthRequestDto.class)))
+                .thenReturn(tokenInfo);
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_토큰을_재발급한다() throws Exception {
+        // given
+        TokenInfo tokenInfo = TokenInfo.create("new-access-token", "new-refresh-token");
+
+        when(authService.reissueToken(any(HttpServletRequest.class)))
+                .thenReturn(tokenInfo);
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_토큰_재발급을_시도하면_권한에error가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_TOTP_인증을_한다() throws Exception {
+        // given
+        TwoFactorAuthenticationRequestDto requestDto = new TwoFactorAuthenticationRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setTotp("123456");
+
+        TokenInfo tokenInfo = TokenInfo.create("access-token", "refresh-token");
+
+        when(authService.authenticate(any(TwoFactorAuthenticationRequestDto.class)))
+                .thenReturn(tokenInfo);
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/two-factor-authentication")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 잘못된_TOTP_코드로_인증을_시도하면_예외가_발생한다() throws Exception {
+        // given
+        TwoFactorAuthenticationRequestDto requestDto = new TwoFactorAuthenticationRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setTotp("000000");
+
+        when(authService.authenticate(any(TwoFactorAuthenticationRequestDto.class)))
+                .thenThrow(new BaseException(ErrorCode.BAD_CREDENTIALS, "잘못된 TOTP 코드입니다."));
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/two-factor-authentication")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_TOTP_인증을_시도한다() throws Exception {
+        // given
+        TwoFactorAuthenticationRequestDto requestDto = new TwoFactorAuthenticationRequestDto();
+        requestDto.setDeviceTag("490154203237518");
+        requestDto.setTotp("123456");
+
+        TokenInfo tokenInfo = TokenInfo.create("access-token", "refresh-token");
+
+        when(authService.authenticate(any(TwoFactorAuthenticationRequestDto.class)))
+                .thenReturn(tokenInfo);
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/two-factor-authentication")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void 정상적으로_TOTP_초기화한다() throws Exception {
+        // given
+        String deviceTag = "490154203237518";
+        String returnedDeviceTag = "490154203237518";
+
+        when(authService.resetAuthenticator(eq(deviceTag)))
+                .thenReturn(returnedDeviceTag);
+
+        // when
+        mockMvc.perform(delete("/api/v1/auth/two-factor-authentication/{deviceTag}", deviceTag)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(returnedDeviceTag));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 비관리자가_TOTP_초기화를_시도하면_권한에러가_발생한다() throws Exception {
+        // given
+        String deviceTag = "490154203237518";
+
+        // when
+        mockMvc.perform(delete("/api/v1/auth/two-factor-authentication/{deviceTag}", deviceTag)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_TOTP_초기화를_시도하면_권한에러가_발생한다() throws Exception {
+        // given
+        String deviceTag = "490154203237518";
+
+        // when
+        mockMvc.perform(delete("/api/v1/auth/two-factor-authentication/{deviceTag}", deviceTag)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 토큰_재발급시_잘못된_리프레시_토큰으로_인해_예외가_발생한다() throws Exception {
+        // given
+        when(authService.reissueToken(any(HttpServletRequest.class)))
+                .thenThrow(new BaseException(ErrorCode.TOKEN_INVALID, "잘못된 리프레시 토큰입니다."));
+
+        // when
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+}

--- a/stempo-api/src/test/java/com/stempo/controller/BoardControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/BoardControllerTest.java
@@ -1,0 +1,286 @@
+package com.stempo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.dto.PagedResponseDto;
+import com.stempo.dto.request.BoardRequestDto;
+import com.stempo.dto.request.BoardUpdateRequestDto;
+import com.stempo.dto.response.BoardResponseDto;
+import com.stempo.model.BoardCategory;
+import com.stempo.service.BoardService;
+import com.stempo.test.TestApplication;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = BoardController.class)
+@ContextConfiguration(classes = TestApplication.class)
+@ActiveProfiles("test")
+class BoardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BoardService boardService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_게시글을_등록한다() throws Exception {
+        // given
+        BoardRequestDto requestDto = new BoardRequestDto();
+        requestDto.setCategory(BoardCategory.NOTICE);
+        requestDto.setTitle("청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo.");
+        requestDto.setContent("Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다.");
+        requestDto.setFileUrls(List.of(
+                "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav",
+                "/resources/files/boards/1/1030487120626166_1dec3611-c148-4139-bb16-3d2a89ac1dd7.pdf"
+        ));
+
+        Long expectedBoardId = 1L;
+
+        when(boardService.registerBoard(any(BoardRequestDto.class)))
+                .thenReturn(expectedBoardId);
+
+        // when
+        mockMvc.perform(post("/api/v1/boards")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(expectedBoardId));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 유효하지_않은_입력값으로_게시글을_등록시_예외가_발생한다() throws Exception {
+        // given
+        BoardRequestDto requestDto = new BoardRequestDto();
+        requestDto.setCategory(null);
+        requestDto.setTitle("");
+        requestDto.setContent("");
+
+        // when
+        mockMvc.perform(post("/api/v1/boards")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_게시글을_등록시_권한에러가_발생한다() throws Exception {
+        // given
+        BoardRequestDto requestDto = new BoardRequestDto();
+        requestDto.setCategory(BoardCategory.NOTICE);
+        requestDto.setTitle("청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo.");
+        requestDto.setContent("Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다.");
+        requestDto.setFileUrls(List.of(
+                "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav",
+                "/resources/files/boards/1/1030487120626166_1dec3611-c148-4139-bb16-3d2a89ac1dd7.pdf"
+        ));
+
+        // when
+        mockMvc.perform(post("/api/v1/boards")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_카테고리별_게시글을_조회한다() throws Exception {
+        // given
+        BoardCategory category = BoardCategory.NOTICE;
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+        BoardResponseDto board1 = BoardResponseDto.builder()
+                .id(1L)
+                .deviceTag("490154203237518")
+                .category(BoardCategory.NOTICE)
+                .title("청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo.")
+                .content("Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다.")
+                .fileUrls(List.of(
+                        "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav",
+                        "/resources/files/boards/1/1030487120626166_1dec3611-c148-4139-bb16-3d2a89ac1dd7.pdf"
+                ))
+                .createdAt("2024-01-01T00:00:00")
+                .build();
+
+        BoardResponseDto board2 = BoardResponseDto.builder()
+                .id(2L)
+                .deviceTag("490154203237518")
+                .category(BoardCategory.NOTICE)
+                .title("새로운 공지사항 업데이트")
+                .content("새로운 공지사항이 업데이트되었습니다.")
+                .fileUrls(List.of())
+                .createdAt("2024-01-02T00:00:00")
+                .build();
+
+        List<BoardResponseDto> boardList = List.of(board1, board2);
+        PagedResponseDto<BoardResponseDto> expectedPagedResponse = new PagedResponseDto<>(
+                new PageImpl<>(boardList, pageable, boardList.size())
+        );
+
+        Mockito.when(boardService.getBoardsByCategory(eq(category), eq(pageable)))
+                .thenReturn(expectedPagedResponse);
+
+        // when
+        mockMvc.perform(get("/api/v1/boards")
+                        .param("category", "NOTICE")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortBy", "createdAt")
+                        .param("sortDirection", "desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
+                .andExpect(jsonPath("$.data.hasPrevious").value(false))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.totalItems").value(2))
+                .andExpect(jsonPath("$.data.take").value(2))
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].id").value(1))
+                .andExpect(jsonPath("$.data.items[0].deviceTag").value("490154203237518"))
+                .andExpect(jsonPath("$.data.items[0].category").value("NOTICE"))
+                .andExpect(jsonPath("$.data.items[0].title").value("청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo."))
+                .andExpect(jsonPath("$.data.items[0].content").value("Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다."))
+                .andExpect(jsonPath("$.data.items[0].fileUrls").isArray())
+                .andExpect(jsonPath("$.data.items[0].fileUrls[0]").value(
+                        "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav"))
+                .andExpect(jsonPath("$.data.items[0].fileUrls[1]").value(
+                        "/resources/files/boards/1/1030487120626166_1dec3611-c148-4139-bb16-3d2a89ac1dd7.pdf"))
+                .andExpect(jsonPath("$.data.items[0].createdAt").value("2024-01-01T00:00:00"))
+                .andExpect(jsonPath("$.data.items[1].id").value(2))
+                .andExpect(jsonPath("$.data.items[1].deviceTag").value("490154203237518"))
+                .andExpect(jsonPath("$.data.items[1].category").value("NOTICE"))
+                .andExpect(jsonPath("$.data.items[1].title").value("새로운 공지사항 업데이트"))
+                .andExpect(jsonPath("$.data.items[1].content").value("새로운 공지사항이 업데이트되었습니다."))
+                .andExpect(jsonPath("$.data.items[1].fileUrls").isArray())
+                .andExpect(jsonPath("$.data.items[1].fileUrls").isEmpty())
+                .andExpect(jsonPath("$.data.items[1].createdAt").value("2024-01-02T00:00:00"));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_카테고리별_게시글을_조회시_권한에러가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(get("/api/v1/boards")
+                        .param("category", "NOTICE")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortBy", "createdAt")
+                        .param("sortDirection", "desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_게시글을_수정한다() throws Exception {
+        // given
+        Long boardId = 1L;
+        BoardUpdateRequestDto updateRequestDto = new BoardUpdateRequestDto();
+        updateRequestDto.setCategory(BoardCategory.NOTICE);
+        updateRequestDto.setTitle("청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo. (수정)");
+        updateRequestDto.setContent("Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다. (수정)");
+        updateRequestDto.setFileUrls(List.of(
+                "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav"
+        ));
+
+        Long expectedBoardId = 1L;
+
+        when(boardService.updateBoard(eq(boardId), any(BoardUpdateRequestDto.class)))
+                .thenReturn(expectedBoardId);
+
+        // when
+        mockMvc.perform(patch("/api/v1/boards/{boardId}", boardId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(expectedBoardId));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_게시글을_수정시_권한에러가_발생한다() throws Exception {
+        // given
+        Long boardId = 1L;
+        BoardUpdateRequestDto updateRequestDto = new BoardUpdateRequestDto();
+        updateRequestDto.setCategory(BoardCategory.NOTICE);
+        updateRequestDto.setTitle("청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스, Stempo. (수정)");
+        updateRequestDto.setContent("Stempo는 청각 자극을 통한 뇌성마비 환자 보행 패턴 개선 서비스입니다. (수정)");
+        updateRequestDto.setFileUrls(List.of(
+                "/resources/files/947051880039041_19dea234-b6ec-4c4b-bc92-c53c0d921943.wav"
+        ));
+
+        // when
+        mockMvc.perform(patch("/api/v1/boards/{boardId}", boardId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_게시글을_삭제한다() throws Exception {
+        // given
+        Long boardId = 1L;
+
+        when(boardService.deleteBoard(eq(boardId)))
+                .thenReturn(boardId);
+
+        // when
+        mockMvc.perform(delete("/api/v1/boards/{boardId}", boardId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(boardId));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_게시글을_삭제시_권한에러가_발생한다() throws Exception {
+        // given
+        Long boardId = 1L;
+
+        // when
+        mockMvc.perform(delete("/api/v1/boards/{boardId}", boardId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/stempo-api/src/test/java/com/stempo/controller/FileControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/FileControllerTest.java
@@ -1,0 +1,249 @@
+package com.stempo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.dto.PagedResponseDto;
+import com.stempo.dto.request.DeleteFileRequestDto;
+import com.stempo.dto.response.UploadedFileResponseDto;
+import com.stempo.exception.BaseException;
+import com.stempo.exception.ErrorCode;
+import com.stempo.service.FileService;
+import com.stempo.test.TestApplication;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = FileController.class)
+@ContextConfiguration(classes = TestApplication.class)
+@ActiveProfiles("test")
+class FileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FileService fileService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_게시판_파일을_업로드한다() throws Exception {
+        // given
+        MockMultipartFile file1 = new MockMultipartFile(
+                "multipartFile",
+                "file1.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "Hello, World!".getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartFile file2 = new MockMultipartFile(
+                "multipartFile",
+                "file2.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "Spring Boot Testing".getBytes(StandardCharsets.UTF_8)
+        );
+
+        List<String> expectedFilePaths = List.of(
+                "/resources/files/boards/file1.txt",
+                "/resources/files/boards/file2.txt"
+        );
+
+        when(fileService.saveFiles(any(List.class), eq("boards")))
+                .thenReturn(expectedFilePaths);
+
+        // when
+        mockMvc.perform(multipart("/api/v1/files/boards")
+                        .file(file1)
+                        .file(file2)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0]").value("/resources/files/boards/file1.txt"))
+                .andExpect(jsonPath("$.data[1]").value("/resources/files/boards/file2.txt"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 유효하지_않은_입력값으로_게시판_파일을_업로드시_예외가_발생한다() throws Exception {
+        // given
+        List<String> expectedFilePaths = List.of();
+
+        when(fileService.saveFiles(any(List.class), eq("boards")))
+                .thenReturn(expectedFilePaths);
+
+        // when
+        mockMvc.perform(multipart("/api/v1/files/boards")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_게시판_파일을_업로드시_권한에러가_발생한다() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "multipartFile",
+                "file.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "Unauthorized access".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        mockMvc.perform(multipart("/api/v1/files/boards")
+                        .file(file)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void 정상적으로_파일_목록을_조회한다() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+        UploadedFileResponseDto file1 = UploadedFileResponseDto.builder()
+                .originalFileName("file1.txt")
+                .url("/resources/files/file1.txt")
+                .fileSize("1.0KB")
+                .createdAt(LocalDateTime.parse("2024-10-01T00:00:00"))
+                .build();
+
+        UploadedFileResponseDto file2 = UploadedFileResponseDto.builder()
+                .originalFileName("file2.txt")
+                .url("/resources/files/file2.txt")
+                .fileSize("2.0KB")
+                .createdAt(LocalDateTime.parse("2024-10-02T00:00:00"))
+                .build();
+
+        List<UploadedFileResponseDto> fileList = List.of(file1, file2);
+        PagedResponseDto<UploadedFileResponseDto> expectedPagedResponse = new PagedResponseDto<>(
+                new PageImpl<>(fileList, pageable, fileList.size())
+        );
+
+        when(fileService.getFiles(eq(pageable)))
+                .thenReturn(expectedPagedResponse);
+
+        // when
+        mockMvc.perform(get("/api/v1/files")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortBy", "createdAt")
+                        .param("sortDirection", "desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
+                .andExpect(jsonPath("$.data.hasPrevious").value(false))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.totalItems").value(2))
+                .andExpect(jsonPath("$.data.take").value(2))
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].originalFileName").value("file1.txt"))
+                .andExpect(jsonPath("$.data.items[0].url").value("/resources/files/file1.txt"))
+                .andExpect(jsonPath("$.data.items[0].fileSize").value("1.0KB"))
+                .andExpect(jsonPath("$.data.items[0].createdAt").value("2024-10-01T00:00:00"))
+                .andExpect(jsonPath("$.data.items[1].originalFileName").value("file2.txt"))
+                .andExpect(jsonPath("$.data.items[1].url").value("/resources/files/file2.txt"))
+                .andExpect(jsonPath("$.data.items[1].fileSize").value("2.0KB"))
+                .andExpect(jsonPath("$.data.items[1].createdAt").value("2024-10-02T00:00:00"));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_파일_목록을_조회시_권한에러가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(get("/api/v1/files")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortBy", "createdAt")
+                        .param("sortDirection", "desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void 정상적으로_파일을_삭제한다() throws Exception {
+        // given
+        DeleteFileRequestDto requestDto = new DeleteFileRequestDto();
+        requestDto.setUrl("/resources/files/file1.txt");
+
+        when(fileService.deleteFile(any(DeleteFileRequestDto.class)))
+                .thenReturn(true);
+
+        // when
+        mockMvc.perform(delete("/api/v1/files")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void 파일_삭제시_존재하지_않는_파일_경로를_요청하면_예외가_발생한다() throws Exception {
+        // given
+        DeleteFileRequestDto requestDto = new DeleteFileRequestDto();
+        requestDto.setUrl("/resources/files/nonexistent.txt");
+
+        when(fileService.deleteFile(any(DeleteFileRequestDto.class)))
+                .thenThrow(new BaseException(ErrorCode.FILE_DELETE_FAILED, "파일 삭제에 실패했습니다."));
+
+        // when
+        mockMvc.perform(delete("/api/v1/files")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_파일을_삭제시_권한에러가_발생한다() throws Exception {
+        // given
+        DeleteFileRequestDto requestDto = new DeleteFileRequestDto();
+        requestDto.setUrl("/resources/files/file1.txt");
+
+        // when
+        mockMvc.perform(delete("/api/v1/files")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/stempo-api/src/test/java/com/stempo/controller/HomeworkControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/HomeworkControllerTest.java
@@ -1,0 +1,224 @@
+package com.stempo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.dto.PagedResponseDto;
+import com.stempo.dto.request.HomeworkRequestDto;
+import com.stempo.dto.request.HomeworkUpdateRequestDto;
+import com.stempo.dto.response.HomeworkResponseDto;
+import com.stempo.service.HomeworkService;
+import com.stempo.test.TestApplication;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = HomeworkController.class)
+@ContextConfiguration(classes = TestApplication.class)
+@ActiveProfiles("test")
+public class HomeworkControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HomeworkService homeworkService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_과제를_추가한다() throws Exception {
+        // given
+        HomeworkRequestDto requestDto = new HomeworkRequestDto();
+        requestDto.setDescription("매일 스트레칭 운동 진행");
+
+        Long expectedHomeworkId = 1L;
+
+        when(homeworkService.addHomework(any(HomeworkRequestDto.class)))
+                .thenReturn(expectedHomeworkId);
+
+        // when
+        mockMvc.perform(post("/api/v1/homeworks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(expectedHomeworkId));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 유효하지_않은_입력값으로_과제를_추가시_예외가_발생한다() throws Exception {
+        // given
+        HomeworkRequestDto requestDto = new HomeworkRequestDto();
+        requestDto.setDescription("");
+
+        // when
+        mockMvc.perform(post("/api/v1/homeworks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_과제를_추가시_권한에러가_발생한다() throws Exception {
+        // given
+        HomeworkRequestDto requestDto = new HomeworkRequestDto();
+        requestDto.setDescription("매일 스트레칭 운동 진행");
+
+        // when
+        mockMvc.perform(post("/api/v1/homeworks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_과제를_조회한다() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("completed").ascending().and(Sort.by("id").ascending()));
+
+        PagedResponseDto<HomeworkResponseDto> expectedPagedResponse = new PagedResponseDto<>(
+                List.of(
+                        HomeworkResponseDto.builder()
+                                .id(1L)
+                                .description("매일 스트레칭 운동 진행")
+                                .completed(false)
+                                .build(),
+                        HomeworkResponseDto.builder()
+                                .id(2L)
+                                .description("주 3회 보행 훈련 참석")
+                                .completed(true)
+                                .build()
+                ),
+                pageable,
+                2
+        );
+
+        when(homeworkService.getHomeworks(
+                eq(null),
+                any(Pageable.class)))
+                .thenReturn(expectedPagedResponse);
+
+        // when
+        mockMvc.perform(get("/api/v1/homeworks")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].id").value(1))
+                .andExpect(jsonPath("$.data.items[0].description").value("매일 스트레칭 운동 진행"))
+                .andExpect(jsonPath("$.data.items[0].completed").value(false))
+                .andExpect(jsonPath("$.data.items[1].id").value(2))
+                .andExpect(jsonPath("$.data.items[1].description").value("주 3회 보행 훈련 참석"))
+                .andExpect(jsonPath("$.data.items[1].completed").value(true));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_과제를_조회시_권한에러가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(get("/api/v1/homeworks")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_과제를_수정한다() throws Exception {
+        // given
+        Long homeworkId = 1L;
+        HomeworkUpdateRequestDto updateRequestDto = new HomeworkUpdateRequestDto();
+        updateRequestDto.setDescription("매일 아침 보행 훈련 진행");
+
+        Long expectedHomeworkId = 1L;
+
+        when(homeworkService.updateHomework(eq(homeworkId), any(HomeworkUpdateRequestDto.class)))
+                .thenReturn(expectedHomeworkId);
+
+        // when
+        mockMvc.perform(patch("/api/v1/homeworks/{homeworkId}", homeworkId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(expectedHomeworkId));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_과제를_수정시_권한에러가_발생한다() throws Exception {
+        // given
+        Long homeworkId = 1L;
+        HomeworkUpdateRequestDto updateRequestDto = new HomeworkUpdateRequestDto();
+        updateRequestDto.setDescription("매일 아침 보행 훈련 진행");
+
+        // when
+        mockMvc.perform(patch("/api/v1/homeworks/{homeworkId}", homeworkId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_과제를_삭제한다() throws Exception {
+        // given
+        Long homeworkId = 1L;
+
+        when(homeworkService.deleteHomework(eq(homeworkId)))
+                .thenReturn(homeworkId);
+
+        // when
+        mockMvc.perform(delete("/api/v1/homeworks/{homeworkId}", homeworkId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(homeworkId));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_과제를_삭제시_권한에러가_발생한다() throws Exception {
+        // given
+        Long homeworkId = 1L;
+
+        // when
+        mockMvc.perform(delete("/api/v1/homeworks/{homeworkId}", homeworkId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/stempo-api/src/test/java/com/stempo/controller/RecordControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/RecordControllerTest.java
@@ -1,0 +1,188 @@
+package com.stempo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.dto.request.RecordRequestDto;
+import com.stempo.dto.response.RecordResponseDto;
+import com.stempo.dto.response.RecordStatisticsResponseDto;
+import com.stempo.service.RecordService;
+import com.stempo.test.TestApplication;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = RecordController.class)
+@ContextConfiguration(classes = TestApplication.class)
+@ActiveProfiles("test")
+public class RecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RecordService recordService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_보행_훈련_기록을_생성한다() throws Exception {
+        // given
+        RecordRequestDto requestDto = new RecordRequestDto();
+        requestDto.setAccuracy(95.5);
+        requestDto.setDuration(30);
+        requestDto.setSteps(5000);
+
+        String expectedDeviceTag = "device123";
+
+        when(recordService.record(any(RecordRequestDto.class)))
+                .thenReturn(expectedDeviceTag);
+
+        // when
+        mockMvc.perform(post("/api/v1/records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(expectedDeviceTag));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 유효하지_않은_입력값으로_보행_훈련_기록을_생성시_예외가_발생한다() throws Exception {
+        // given
+        RecordRequestDto requestDto = new RecordRequestDto();
+        requestDto.setAccuracy(-10.0);
+        requestDto.setDuration(-5);
+        requestDto.setSteps(-1000);
+
+        // when
+        mockMvc.perform(post("/api/v1/records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_보행_훈련_기록을_생성시_권한에러가_발생한다() throws Exception {
+        // given
+        RecordRequestDto requestDto = new RecordRequestDto();
+        requestDto.setAccuracy(95.5);
+        requestDto.setDuration(30);
+        requestDto.setSteps(5000);
+
+        // when
+        mockMvc.perform(post("/api/v1/records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_보행_훈련_기록을_조회한다() throws Exception {
+        // given
+        LocalDate startDate = LocalDate.of(2024, 10, 1);
+        LocalDate endDate = LocalDate.of(2024, 10, 31);
+
+        List<RecordResponseDto> expectedRecords = List.of(
+                RecordResponseDto.builder()
+                        .accuracy(95.5)
+                        .duration(30)
+                        .steps(5000)
+                        .date(LocalDate.of(2024, 10, 15))
+                        .build(),
+                RecordResponseDto.builder()
+                        .accuracy(90.0)
+                        .duration(25)
+                        .steps(4500)
+                        .date(LocalDate.of(2024, 10, 20))
+                        .build()
+        );
+
+        when(recordService.getRecordsByDateRange(startDate, endDate))
+                .thenReturn(expectedRecords);
+
+        // when
+        mockMvc.perform(get("/api/v1/records")
+                        .param("startDate", "2024-10-01")
+                        .param("endDate", "2024-10-31")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].accuracy").value(95.5))
+                .andExpect(jsonPath("$.data[0].duration").value(30))
+                .andExpect(jsonPath("$.data[0].steps").value(5000))
+                .andExpect(jsonPath("$.data[0].date").value("2024-10-15"))
+                .andExpect(jsonPath("$.data[1].accuracy").value(90.0))
+                .andExpect(jsonPath("$.data[1].duration").value(25))
+                .andExpect(jsonPath("$.data[1].steps").value(4500))
+                .andExpect(jsonPath("$.data[1].date").value("2024-10-20"));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_보행_훈련_기록을_조회시_권한에러가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(get("/api/v1/records")
+                        .param("startDate", "2024-10-01")
+                        .param("endDate", "2024-10-31")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_보행_훈련_기록_통계를_조회한다() throws Exception {
+        // given
+        RecordStatisticsResponseDto expectedStatistics = RecordStatisticsResponseDto.builder()
+                .todayWalkTrainingCount(10)
+                .weeklyWalkTrainingCount(50)
+                .consecutiveWalkTrainingDays(5)
+                .build();
+
+        when(recordService.getRecordStatistics())
+                .thenReturn(expectedStatistics);
+
+        // when
+        mockMvc.perform(get("/api/v1/records/statistics")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.todayWalkTrainingCount").value(10))
+                .andExpect(jsonPath("$.data.weeklyWalkTrainingCount").value(50))
+                .andExpect(jsonPath("$.data.consecutiveWalkTrainingDays").value(5));
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_보행_훈련_기록_통계를_조회시_권한에러가_발생한다() throws Exception {
+        // when
+        mockMvc.perform(get("/api/v1/records/statistics")
+                        .contentType(MediaType.APPLICATION_JSON))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/stempo-api/src/test/java/com/stempo/controller/RhythmControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/RhythmControllerTest.java
@@ -44,10 +44,12 @@ public class RhythmControllerTest {
 
         String expectedFilePath = "/resources/files/rhythm_120_4_bpm.wav";
 
-        when(rhythmService.createRhythm(any(RhythmRequestDto.class))).thenReturn(expectedFilePath);
+        when(rhythmService.createRhythm(any(RhythmRequestDto.class)))
+                .thenReturn(expectedFilePath);
 
         // when
-        mockMvc.perform(post("/api/v1/rhythm").contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(post("/api/v1/rhythm")
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 // then
                 .andExpect(status().isOk())
@@ -64,7 +66,8 @@ public class RhythmControllerTest {
         requestDto.setBit(4);
 
         // when
-        mockMvc.perform(post("/api/v1/rhythm").contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(post("/api/v1/rhythm")
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 // then
                 .andExpect(status().isBadRequest())
@@ -80,7 +83,8 @@ public class RhythmControllerTest {
         requestDto.setBit(4);
 
         // when
-        mockMvc.perform(post("/api/v1/rhythm").contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(post("/api/v1/rhythm")
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 // then
                 .andExpect(status().isUnauthorized());

--- a/stempo-api/src/test/java/com/stempo/controller/RhythmControllerTest.java
+++ b/stempo-api/src/test/java/com/stempo/controller/RhythmControllerTest.java
@@ -1,0 +1,88 @@
+package com.stempo.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stempo.dto.request.RhythmRequestDto;
+import com.stempo.service.RhythmService;
+import com.stempo.test.TestApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = RhythmController.class)
+@ContextConfiguration(classes = TestApplication.class)
+@ActiveProfiles("test")
+public class RhythmControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RhythmService rhythmService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 정상적으로_리듬을_생성한다() throws Exception {
+        // given
+        RhythmRequestDto requestDto = new RhythmRequestDto();
+        requestDto.setBpm(120);
+        requestDto.setBit(4);
+
+        String expectedFilePath = "/resources/files/rhythm_120_4_bpm.wav";
+
+        when(rhythmService.createRhythm(any(RhythmRequestDto.class))).thenReturn(expectedFilePath);
+
+        // when
+        mockMvc.perform(post("/api/v1/rhythm").contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(expectedFilePath));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 유효하지_않은_입력값으로_리듬_생성시_예외가_발생한다() throws Exception {
+        // given
+        RhythmRequestDto requestDto = new RhythmRequestDto();
+        requestDto.setBpm(5);
+        requestDto.setBit(4);
+
+        // when
+        mockMvc.perform(post("/api/v1/rhythm").contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_리듬_생성시_권한에러가_발생한다() throws Exception {
+        // given
+        RhythmRequestDto requestDto = new RhythmRequestDto();
+        requestDto.setBpm(120);
+        requestDto.setBit(4);
+
+        // when
+        mockMvc.perform(post("/api/v1/rhythm").contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/stempo-api/src/test/java/com/stempo/test/TestApplication.java
+++ b/stempo-api/src/test/java/com/stempo/test/TestApplication.java
@@ -1,0 +1,11 @@
+package com.stempo.test;
+
+import com.stempo.exception.GlobalExceptionHandler;
+import com.stempo.test.config.TestSecurityConfig;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+@SpringBootApplication(scanBasePackages = {"com.stempo.controller", "com.stempo.exception"})
+@Import({GlobalExceptionHandler.class, TestSecurityConfig.class})
+public class TestApplication {
+}

--- a/stempo-api/src/test/java/com/stempo/test/config/TestSecurityConfig.java
+++ b/stempo-api/src/test/java/com/stempo/test/config/TestSecurityConfig.java
@@ -2,7 +2,9 @@ package com.stempo.test.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,7 +14,14 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class TestSecurityConfig {
+
+    public static final String[] PERMIT_ALL_API_ENDPOINTS_POST = {
+            "/api/v1/auth/register",
+            "/api/v1/auth/login",
+            "/api/v1/auth/two-factor-authentication"
+    };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -22,7 +31,9 @@ public class TestSecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(authorizeRequests ->
-                        authorizeRequests.anyRequest().authenticated()
+                        authorizeRequests
+                                .requestMatchers(HttpMethod.POST, PERMIT_ALL_API_ENDPOINTS_POST).permitAll()
+                                .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandling ->
                         exceptionHandling.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))

--- a/stempo-api/src/test/java/com/stempo/test/config/TestSecurityConfig.java
+++ b/stempo-api/src/test/java/com/stempo/test/config/TestSecurityConfig.java
@@ -1,0 +1,32 @@
+package com.stempo.test.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests.anyRequest().authenticated()
+                )
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                );
+        return http.build();
+    }
+}

--- a/stempo-application/src/main/java/com/stempo/service/RecordServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/RecordServiceImpl.java
@@ -119,5 +119,4 @@ public class RecordServiceImpl implements RecordService {
         }
         return consecutiveDays;
     }
-
 }

--- a/stempo-application/src/main/java/com/stempo/service/TotpService.java
+++ b/stempo-application/src/main/java/com/stempo/service/TotpService.java
@@ -39,7 +39,7 @@ public class TotpService {
         userService.handleAccountLock(deviceTag);
         if (!authenticatorService.isAuthenticatorValid(deviceTag, totp)) {
             userService.handleFailedLogin(deviceTag);
-            throw new BadCredentialsException("Invalid TOTP code.");
+            throw new BadCredentialsException("잘못된 TOTP 코드입니다.");
         }
     }
 

--- a/stempo-application/src/test/java/com/stempo/service/TotpServiceTest.java
+++ b/stempo-application/src/test/java/com/stempo/service/TotpServiceTest.java
@@ -89,7 +89,7 @@ class TotpServiceTest {
         // when, then
         assertThatThrownBy(() -> totpService.authenticate(requestDto, tokenService))
                 .isInstanceOf(BadCredentialsException.class)
-                .hasMessage("Invalid TOTP code.");
+                .hasMessage("잘못된 TOTP 코드입니다.");
 
         verify(userService).handleAccountLock(encryptedDeviceTag);
         verify(authenticatorService).isAuthenticatorValid(encryptedDeviceTag, requestDto.getTotp());

--- a/stempo-common/src/main/java/com/stempo/exception/ErrorCode.java
+++ b/stempo-common/src/main/java/com/stempo/exception/ErrorCode.java
@@ -29,7 +29,6 @@ public enum ErrorCode {
     UNKNOWN_PATH(HttpStatus.BAD_REQUEST, "쿼리의 경로가 잘못되었습니다."),
 
     // 401 UNAUTHORIZED Errors
-    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "접근이 거부되었습니다."),
     AUTHENTICATION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보를 찾을 수 없습니다."),
     BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 인증 정보입니다."),
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
@@ -42,6 +41,10 @@ public enum ErrorCode {
     USERNAME_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 이름을 찾을 수 없습니다."),
 
     // 403 FORBIDDEN Errors
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+    AUTHORIZATION_DENIED(HttpStatus.FORBIDDEN, "권한이 거부되었습니다."),
+    AUTHORIZATION_SERVICE_ERROR(HttpStatus.FORBIDDEN, "권한 서비스 오류가 발생했습니다."),
+    FILE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "파일 접근이 거부되었습니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 거부되었습니다."),
 
     // 404 NOT_FOUND Errors

--- a/stempo-common/src/main/java/com/stempo/exception/ExceptionMapper.java
+++ b/stempo-common/src/main/java/com/stempo/exception/ExceptionMapper.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.validation.ConstraintViolationException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +18,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -51,14 +51,17 @@ public class ExceptionMapper {
         exceptionToErrorCodeMap.put(io.jsonwebtoken.security.SecurityException.class, ErrorCode.JWT_SECURITY_ERROR);
 
         // 401 UNAUTHORIZED Errors
-        exceptionToErrorCodeMap.put(AccessDeniedException.class, ErrorCode.ACCESS_DENIED);
-        exceptionToErrorCodeMap.put(AuthorizationDeniedException.class, ErrorCode.ACCESS_DENIED);
-        exceptionToErrorCodeMap.put(AuthorizationServiceException.class, ErrorCode.ACCESS_DENIED);
         exceptionToErrorCodeMap.put(BadCredentialsException.class, ErrorCode.BAD_CREDENTIALS);
         exceptionToErrorCodeMap.put(ExpiredJwtException.class, ErrorCode.EXPIRED_JWT);
         exceptionToErrorCodeMap.put(MalformedJwtException.class, ErrorCode.MALFORMED_JWT);
         exceptionToErrorCodeMap.put(UnsupportedJwtException.class, ErrorCode.UNSUPPORTED_JWT);
         exceptionToErrorCodeMap.put(UsernameNotFoundException.class, ErrorCode.USERNAME_NOT_FOUND);
+
+        // 403 FORBIDDEN Errors
+        exceptionToErrorCodeMap.put(AccessDeniedException.class, ErrorCode.ACCESS_DENIED);
+        exceptionToErrorCodeMap.put(java.nio.file.AccessDeniedException.class, ErrorCode.FILE_ACCESS_DENIED);
+        exceptionToErrorCodeMap.put(AuthorizationDeniedException.class, ErrorCode.AUTHORIZATION_DENIED);
+        exceptionToErrorCodeMap.put(AuthorizationServiceException.class, ErrorCode.AUTHORIZATION_SERVICE_ERROR);
 
         // 404 NOT_FOUND Errors
         exceptionToErrorCodeMap.put(FileNotFoundException.class, ErrorCode.FILE_NOT_FOUND);

--- a/stempo-common/src/test/java/com/stempo/exception/ExceptionMapperTest.java
+++ b/stempo-common/src/test/java/com/stempo/exception/ExceptionMapperTest.java
@@ -9,7 +9,6 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.validation.ConstraintViolationException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.sql.SQLException;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionException;
@@ -22,6 +21,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authorization.AuthorizationDecision;
@@ -69,18 +69,23 @@ class ExceptionMapperTest {
                 ExceptionMapper.getErrorCode(new io.jsonwebtoken.security.SecurityException("")));
 
         // 401 UNAUTHORIZED Errors
-        assertEquals(ErrorCode.ACCESS_DENIED, ExceptionMapper.getErrorCode(new AccessDeniedException("")));
-
-        AuthorizationDecision decision = new AuthorizationDecision(false);
-        assertEquals(ErrorCode.ACCESS_DENIED,
-                ExceptionMapper.getErrorCode(new AuthorizationDeniedException("권한 거부", decision)));
-
-        assertEquals(ErrorCode.ACCESS_DENIED, ExceptionMapper.getErrorCode(new AuthorizationServiceException("")));
         assertEquals(ErrorCode.BAD_CREDENTIALS, ExceptionMapper.getErrorCode(new BadCredentialsException("")));
         assertEquals(ErrorCode.EXPIRED_JWT, ExceptionMapper.getErrorCode(new ExpiredJwtException(null, null, "")));
         assertEquals(ErrorCode.MALFORMED_JWT, ExceptionMapper.getErrorCode(new MalformedJwtException("")));
         assertEquals(ErrorCode.UNSUPPORTED_JWT, ExceptionMapper.getErrorCode(new UnsupportedJwtException("")));
         assertEquals(ErrorCode.USERNAME_NOT_FOUND, ExceptionMapper.getErrorCode(new UsernameNotFoundException("")));
+
+        // 403 FORBIDDEN Errors
+        assertEquals(ErrorCode.ACCESS_DENIED, ExceptionMapper.getErrorCode(new AccessDeniedException("")));
+        assertEquals(ErrorCode.FILE_ACCESS_DENIED,
+                ExceptionMapper.getErrorCode(new java.nio.file.AccessDeniedException("")));
+
+        AuthorizationDecision decision = new AuthorizationDecision(false);
+        assertEquals(ErrorCode.AUTHORIZATION_DENIED,
+                ExceptionMapper.getErrorCode(new AuthorizationDeniedException("권한 거부", decision)));
+
+        assertEquals(ErrorCode.AUTHORIZATION_SERVICE_ERROR,
+                ExceptionMapper.getErrorCode(new AuthorizationServiceException("")));
 
         // 404 NOT_FOUND Errors
         assertEquals(ErrorCode.FILE_NOT_FOUND, ExceptionMapper.getErrorCode(new FileNotFoundException()));


### PR DESCRIPTION
## Summary

> #81 

API 레이어에 대한 단위 테스트를 작성하여 각 컨트롤러가 기대대로 동작하는지 검증했습니다. `@WebMvcTest` 어노테이션을 활용하여 API 요청과 응답을 테스트하고, 예외 처리 및 권한 검증 로직의 정상 작동 여부도 확인했습니다.

## Tasks

- 각 컨트롤러에 대한 API 단위 테스트 코드 작성
- 각 API 엔드포인트에 대한 요청 및 응답 검증