### PR TITLE
refactor: CD 파이프라인 이미지 최적화 및 빌드 성능 개선을 위한 Docker Multi-stage Build, Spring Layered JAR 및 BuildKit 도입 완료

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Ignore Git-related files
+.git
+.gitignore
+
+# Ignore local IDE files
+.idea/
+*.iml
+*.log
+
+# Ignore build directories
+build/
+out/
+target/
+
+# Ignore Docker-related files
+Dockerfile
+docker-compose.yml
+
+# Ignore other unnecessary files/directories
+*.md
+*.tmp
+*.bak
+*.py
+
+# Ignore specific directories
+cloud/
+config/
+jenkins/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
 	id("java")
 	id("org.springframework.boot") version Versions.springBoot
@@ -37,7 +39,7 @@ allprojects {
 		enabled = true
 	}
 
-	tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+	tasks.named<BootJar>("bootJar") {
 		enabled = false
 	}
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,27 +1,29 @@
-# 1. Gradle 8.11.1 기반 빌드 이미지 생성
+# 1. 빌드 단계
 FROM gradle:8.11.1-jdk21 AS build
 WORKDIR /app
 
-# build.gradle.kts와 settings.gradle, buildSrc 디렉토리를 복사하여 의존성 설치 준비
+# Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
 COPY build.gradle.kts settings.gradle /app/
 COPY buildSrc /app/buildSrc
-
-# 의존성 캐싱을 위해 먼저 의존성만 설치 (빌드 전에 캐시 활용)
 RUN gradle dependencies --parallel --stacktrace
 
-# 소스 파일을 모두 복사한 후 애플리케이션 빌드
+# 소스 코드 복사 및 애플리케이션 빌드
 COPY . /app
-RUN gradle build --parallel --stacktrace
+RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
-# 2. 런타임용 이미지 생성
-FROM openjdk:21-jdk-slim
+# Layered JAR에서 레이어 추출
+RUN java -Djarmode=layertools -jar /app/stempo-api/build/libs/stempo-api.jar extract
+
+# 2. 런타임 단계
+FROM openjdk:21-jre-slim AS runtime
 WORKDIR /app
 
-# 빌드 단계에서 생성된 JAR 파일을 런타임 이미지로 복사
-COPY --from=build /app/stempo-api/build/libs/stempo-api.jar stempo-api.jar
+# 추출된 레이어 복사
+COPY --from=build /app/dependencies/ ./
+COPY --from=build /app/spring-boot-loader/ ./
+COPY --from=build /app/snapshot-dependencies/ ./
+COPY --from=build /app/application/ ./
 
-# 애플리케이션이 실행될 포트 설정 (8080)
+# 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-
-# 스프링 프로파일을 prod로 설정하고 JAR 파일 실행
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "stempo-api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -15,7 +15,7 @@ RUN gradle bootJar --no-daemon --build-cache --stacktrace
 RUN java -Djarmode=layertools -jar /app/stempo-api/build/libs/stempo-api.jar extract
 
 # 2. 런타임 단계
-FROM openjdk:21-jre-slim AS runtime
+FROM eclipse-temurin:21-jre AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,5 +1,5 @@
-# 1. Gradle 8.10.2 기반 빌드 이미지 생성
-FROM gradle:8.10.2-jdk21 AS build
+# 1. Gradle 8.11.1 기반 빌드 이미지 생성
+FROM gradle:8.11.1-jdk21 AS build
 WORKDIR /app
 
 # build.gradle.kts와 settings.gradle, buildSrc 디렉토리를 복사하여 의존성 설치 준비

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=build /app/application/ ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -269,6 +269,9 @@ def loadEnvironmentVariables(String configFile) {
     env.PORT_A = config.spring.'port-a'.toString()
     env.PORT_B = config.spring.'port-b'.toString()
 
+    env.WHITELIST_ADMIN_USERNAME = config.admin.username
+    env.WHITELIST_ADMIN_PASSWORD = config.admin.password
+
     env.DOCKERFILE_PATH = "${env.WORKSPACE}${config.docker.'dockerfile-path'}"
     env.NGINX_CONTAINER_NAME = config.docker.'nginx-container-name'
     env.MARIA_DB_CONTAINER_NAME = config.docker.'mariadb-container-name'
@@ -415,7 +418,8 @@ def performHealthCheck() {
         def elapsed = (System.currentTimeMillis() - start_time) / 1000
         echo "Checking health... ${elapsed} seconds elapsed."
         def status = sh(
-            script: """curl -s http://${PUBLIC_IP}:${env.NEW_PORT}${env.ACTUATOR_PATH} | grep 'UP'""",
+            script: """curl -s -u ${env.WHITELIST_ADMIN_USERNAME}:${env.WHITELIST_ADMIN_PASSWORD} \
+                http://${PUBLIC_IP}:${env.NEW_PORT}/actuator/health | grep 'UP'""",
             returnStatus: true
         )
         if (status == 0) {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
             }
         }
 
-        stage('Parallel Processing') {
+        stage('Concurrent Pre-Build Steps') {
             parallel {
                 stage('Get Git Change Log') {
                     steps {
@@ -363,7 +363,7 @@ def determineContainers() {
 
 def buildAndPushDockerImage() {
     sh """
-        docker build -f ${env.DOCKERFILE_PATH} -t ${env.IMAGE_NAME}:${env.DEPLOY_CONTAINER} .
+        DOCKER_BUILDKIT=1 docker build -f ${env.DOCKERFILE_PATH} -t ${env.IMAGE_NAME}:${env.DEPLOY_CONTAINER} .
         docker tag ${env.IMAGE_NAME}:${env.DEPLOY_CONTAINER} ${env.DOCKER_HUB_REPO}:${env.DEPLOY_CONTAINER}
         docker push ${env.DOCKER_HUB_REPO}:${env.DEPLOY_CONTAINER}
     """

--- a/stempo-api/build.gradle.kts
+++ b/stempo-api/build.gradle.kts
@@ -1,8 +1,17 @@
-tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+tasks.named<BootJar>("bootJar") {
     enabled = true
+
+    layered {
+        enabled = true
+    }
+
     archiveBaseName.set(project.name)
     archiveVersion.set("${project.version}")
     archiveFileName.set("${archiveBaseName.get()}.${archiveExtension.get()}")
+
+    mainClass.set("com.stempo.ApiApplication")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

> #88 

Docker Multi-stage Builds와 Spring Boot Layered JAR를 도입하여 이미지 크기를 최적화하고 빌드 속도를 개선했습니다. 이를 통해 컨테이너 빌드 효율성을 높이고, 배포 과정에서의 리소스 소비를 줄였습니다.

## Tasks

- **Docker Multi-stage Builds 적용**
  - 빌드 환경과 런타임 환경을 분리하여 최종 이미지 크기를 줄임.
  - `build.gradle.kts`, `settings.gradle`, `buildSrc`만 복사하여 의존성 캐싱을 적용.
  - Layered JAR를 활용하여 변경 가능성이 낮은 계층을 우선 배치, Docker 캐시 활용도 극대화.

- **Spring Boot Layered JAR 적용**
  - Spring Boot의 `layertools`를 활용하여 JAR 파일을 계층화.
  - Layered JAR에서 `dependencies`, `spring-boot-loader`, `snapshot-dependencies`, `application` 계층을 추출.
  - 런타임 단계에서 계층별로 복사하여 빌드 캐시 최적화.

- **Docker BuildKit 활성화 및 최적화**
  - 환경 변수 설정을 통해 BuildKit을 기본 빌드 도구로 활성화

- **Dockerfile 최적화**
  - 멀티 스테이지 빌드 구조를 도입.
  - `eclipse-temurin:21-jre`을 사용하여 경량화된 런타임 이미지 구성.
  - `bootJar` 빌드 후 레이어를 추출하고, 계층별로 Docker 이미지에 복사.

## ETC

- Gradle 버전이 **8.5**에서 **8.11.1**로 업데이트되었습니다.

## Screenshot

**빌드 속도**: 6.06% 개선 (2m 12s -> 2m 4s)
**이미지 크기**: 46.72% 개선 (281.24 MB -> 149.85 MB)

**적용 전**
![jenkins-before](https://github.com/user-attachments/assets/5ffab10f-3435-4daa-bc13-ea7dbd8c2692)
![image-before](https://github.com/user-attachments/assets/1eebea99-8f8e-4725-ac99-90cfc0d3df8f)

**적용 후**
![jenkins-after](https://github.com/user-attachments/assets/0e097d9b-aed9-475a-88e8-9a3366fb32c5)
![image-after](https://github.com/user-attachments/assets/065fda90-40e5-4da2-aade-c0befdb285e7)