### PR TITLE
refactor: CDS와 AOT 적용으로 Spring Boot 시작 시간 및 메모리 최적화 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,66 +1,81 @@
+import org.springframework.boot.gradle.tasks.aot.ProcessAot
+import org.springframework.boot.gradle.tasks.aot.ProcessTestAot
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
-	id("java")
-	id("org.springframework.boot") version Versions.springBoot
-	id("io.spring.dependency-management") version Versions.springDependencyManagement
+    id("java")
+    id("org.springframework.boot") version Versions.springBoot
+    id("io.spring.dependency-management") version Versions.springDependencyManagement
 }
 
 tasks.named<Jar>("jar") {
-	enabled = false
+    enabled = false
 }
 
 tasks.named<Jar>("bootJar") {
-	enabled = false
+    enabled = false
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":stempo-api"))
 }
 
 allprojects {
-	group = "com.stempo"
-	version = "0.0.1"
+    group = "com.stempo"
+    version = "0.0.1"
 
-	apply(plugin = "java")
+    apply(plugin = "java")
 
-	java {
-		toolchain {
-			languageVersion.set(JavaLanguageVersion.of(21))
-		}
-	}
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
+    }
 
-	apply(plugin = "java")
-	apply(plugin = "java-library")
-	apply(plugin = "org.springframework.boot")
-	apply(plugin = "io.spring.dependency-management")
+    apply(plugin = "java")
+    apply(plugin = "java-library")
+    apply(plugin = "org.springframework.boot")
+    apply(plugin = "org.springframework.boot.aot")
+    apply(plugin = "io.spring.dependency-management")
 
-	tasks.named<Jar>("jar") {
-		enabled = true
-	}
+    tasks.named<Jar>("jar") {
+        enabled = true
+    }
 
-	tasks.named<BootJar>("bootJar") {
-		enabled = false
-	}
+    tasks.named<BootJar>("bootJar") {
+        enabled = false
+    }
 
-	configurations {
-		compileOnly {
-			extendsFrom(configurations.annotationProcessor.get())
-		}
-	}
+    tasks.named<ProcessAot>("processAot") {
+        enabled = false
+    }
 
-	repositories {
-		mavenCentral()
-	}
+    tasks.named<ProcessTestAot>("processTestAot") {
+        enabled = false
+    }
 
-	dependencies {
-		implementation(Dependencies.springBootStarter)
-		testImplementation(Dependencies.springBootStarterTest)
-		compileOnly(Dependencies.lombok)
-		annotationProcessor(Dependencies.lombok)
-	}
+    configurations {
+        compileOnly {
+            extendsFrom(configurations.annotationProcessor.get())
+        }
+    }
 
-	tasks.named<Test>("test") {
-		useJUnitPlatform()
-	}
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        implementation(Dependencies.springBootStarter)
+        testImplementation(Dependencies.springBootStarterTest)
+        compileOnly(Dependencies.lombok)
+        annotationProcessor(Dependencies.lombok)
+    }
+
+    tasks.named<Test>("test") {
+        useJUnitPlatform()
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+spring.aot.enabled=true

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache curl unzip bash && \
     ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
-COPY build.gradle.kts settings.gradle.kts /app/
+COPY build.gradle.kts settings.gradle /app/
 COPY buildSrc /app/buildSrc
 RUN gradle dependencies --parallel --stacktrace
 

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,11 +12,11 @@ COPY . .
 RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
 # Layered JAR에서 레이어 추출
-RUN java -Djarmode=tools -jar stempo-api/build/libs/stempo-api.jar extract
+RUN java -Djarmode=layertools -jar stempo-api/build/libs/stempo-api.jar extract
 
 # CDS 아카이브 생성
 RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
-    -Dspring.datasource.initialization-mode=never \
+    -Dspring.profiles.active=prod \
     -Dspring.context.exit=onRefresh \
     -jar stempo-api/build/libs/stempo-api.jar
 

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -18,13 +18,14 @@ RUN gradle dependencies --parallel --stacktrace
 
 # 소스 코드 복사 및 애플리케이션 빌드
 COPY . /app
-RUN gradle bootJar --no-daemon --build-cache --stacktrace
+RUN gradle bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
 
 # CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
-         -Dspring.profiles.active=cds \
-         -Dspring.context.exit=onRefresh \
-         -jar stempo-api/build/libs/stempo-api.jar
+#RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
+#         -Dspring.aot.enabled=true \
+#         -Dspring.profiles.active=cds \
+#         -Dspring.context.exit=onRefresh \
+#         -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
 FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds
@@ -38,5 +39,5 @@ COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-#ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
-ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
+#ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
+ENTRYPOINT ["java", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -20,7 +20,7 @@ RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
     -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
-FROM eclipse-temurin:21-jre AS runtime
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -20,7 +20,7 @@ RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
     -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
-FROM bellsoft/liberica-runtime-container:jre-21-crac-cds-musl AS runtime
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -38,4 +38,5 @@ COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
+#ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -48,15 +48,15 @@ RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
          org.springframework.boot.loader.launch.JarLauncher
 
 
-# 4. 런타임 단계 \
+# 4. 런타임 단계
 FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
 WORKDIR /app
 
 # 빌드 단계에서 생성된 레이어 복사
-COPY --from=cds /app/dependencies/ ./
-COPY --from=cds /app/spring-boot-loader/ ./
-COPY --from=cds /app/snapshot-dependencies/ ./
-COPY --from=cds /app/application/ ./
+COPY --from=extract /app/dependencies/ ./
+COPY --from=extract /app/spring-boot-loader/ ./
+COPY --from=extract /app/snapshot-dependencies/ ./
+COPY --from=extract /app/application/ ./
 
 # CDS 아카이브 파일 복사
 COPY --from=cds /app/stempo-cds.jsa ./

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -38,7 +38,4 @@ COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java",
-            "-XX:SharedArchiveFile=stempo-cds.jsa",
-            "-Dspring.profiles.active=prod",
-            "-jar", "stempo-api.jar"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,6 +1,15 @@
 # 1. 빌드 단계
-FROM gradle:8.11.1-jdk21 AS build
+FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds AS build
 WORKDIR /app
+
+# Gradle 설치
+ENV GRADLE_VERSION=8.11.1
+RUN apk add --no-cache curl unzip bash && \
+    curl -fsSL https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle.zip && \
+    unzip gradle.zip && \
+    rm gradle.zip && \
+    mv gradle-${GRADLE_VERSION} /opt/gradle && \
+    ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
 COPY build.gradle.kts settings.gradle /app/
@@ -21,7 +30,7 @@ RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
         -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS runtime
+FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,5 +1,5 @@
 # 1. 빌드 단계
-FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5 AS build
+FROM bellsoft/liberica-runtime-container:jdk-21-cds-slim-musl AS build
 WORKDIR /app
 
 # Gradle Wrapper 복사 및 실행 권한 부여

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -16,6 +16,7 @@ RUN java -Djarmode=tools -jar stempo-api/build/libs/stempo-api.jar extract
 
 # CDS 아카이브 생성
 RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
+    -Dspring.datasource.initialization-mode=never \
     -Dspring.context.exit=onRefresh \
     -jar stempo-api/build/libs/stempo-api.jar
 

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -24,18 +24,18 @@ RUN gradle bootJar --no-daemon --build-cache --stacktrace
 RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
          -Dspring.profiles.active=cds \
          -Dspring.context.exit=onRefresh \
-         -jar /app/stempo-api/build/libs/stempo-api.jar
+         -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
 FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds
 WORKDIR /app
 
 # JAR 파일 복사
-COPY --from=build /app/stempo-api/build/libs/stempo-api.jar stempo-api.jar
+COPY --from=build /app/stempo-api/build/libs/stempo-api.jar ./stempo-api/build/libs/stempo-api.jar
 
 # CDS 아카이브 파일 복사
 COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -20,31 +20,25 @@ RUN gradle dependencies --parallel --stacktrace
 COPY . /app
 RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
-# JAR 파일 경로 확인 및 출력
-RUN echo "JAR 파일 위치:" && find /app -name "*.jar"
-
-# Layered JAR에서 레이어 추출
-RUN java -Djarmode=layertools -jar $(find /app -name "stempo-api*.jar") extract
-
 # CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
+RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
          -Dspring.profiles.active=cds \
          -Dspring.context.exit=onRefresh \
-         -jar $(find /app -name "stempo-api*.jar")
+         -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
-FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds AS runtime
+FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds
 WORKDIR /app
 
-# 추출된 레이어 복사
-COPY --from=build /app/dependencies/ ./
-COPY --from=build /app/spring-boot-loader/ ./
-COPY --from=build /app/snapshot-dependencies/ ./
-COPY --from=build /app/application/ ./
+# JAR 파일 복사
+COPY --from=build /app/stempo-api/build/libs/stempo-api.jar stempo-api.jar
 
 # CDS 아카이브 파일 복사
 COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java",
+            "-XX:SharedArchiveFile=stempo-cds.jsa",
+            "-Dspring.profiles.active=prod",
+            "-jar", "stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -21,10 +21,10 @@ COPY . /app
 RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
 # CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
+RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
          -Dspring.profiles.active=cds \
          -Dspring.context.exit=onRefresh \
-         -jar stempo-api/build/libs/stempo-api.jar
+         -jar /app/stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
 FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache curl unzip bash && \
     ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
-COPY build.gradle.kts settings.gradle /app/
+COPY build.gradle.kts settings.gradle gradle.properties /app/
 COPY buildSrc /app/buildSrc
 RUN gradle dependencies --parallel --stacktrace
 

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -45,7 +45,7 @@ RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
          -Dspring.aot.enabled=true \
          -Dspring.profiles.active=cds \
          -Dspring.context.exit=onRefresh \
-         org.springframework.boot.loader.JarLauncher
+         org.springframework.boot.loader.launch.JarLauncher
 
 
 # 4. 런타임 단계 \
@@ -63,4 +63,4 @@ COPY --from=cds /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,42 +1,66 @@
 # 1. 빌드 단계
-FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds AS build
+FROM bellsoft/liberica-runtime-container:jdk-21-cds-slim-musl AS build
 WORKDIR /app
 
-# Gradle 설치
-ENV GRADLE_VERSION=8.11.1
-RUN apk add --no-cache curl unzip bash && \
-    curl -fsSL https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o gradle.zip && \
-    unzip gradle.zip && \
-    rm gradle.zip && \
-    mv gradle-${GRADLE_VERSION} /opt/gradle && \
-    ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle
+# Gradle Wrapper 복사 및 실행 권한 부여
+COPY gradlew /app/
+COPY gradle /app/gradle
+RUN chmod +x ./gradlew
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
 COPY build.gradle.kts settings.gradle gradle.properties /app/
 COPY buildSrc /app/buildSrc
-RUN gradle dependencies --parallel --stacktrace
+RUN ./gradlew dependencies --parallel --stacktrace
 
-# 소스 코드 복사 및 애플리케이션 빌드
+# 소스 코드 복사
 COPY . /app
-RUN gradle bootJar --no-daemon --build-cache --stacktrace
+
+# 애플리케이션 빌드
+RUN ./gradlew bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
+
+
+# 2. Layered JAR 추출 단계
+FROM bellsoft/liberica-runtime-container:jdk-21-cds-slim-musl AS extract
+WORKDIR /app
+
+# 빌드된 JAR 파일 복사
+COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
+
+# Layered JAR 추출
+RUN java -Djarmode=layertools -jar /app/stempo-api.jar extract
+
+
+# 3. CDS 아카이브 생성 단계
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS cds
+WORKDIR /app
+
+# Layered JAR 복사
+COPY --from=extract /app/dependencies/ ./
+COPY --from=extract /app/spring-boot-loader/ ./
+COPY --from=extract /app/snapshot-dependencies/ ./
+COPY --from=extract /app/application/ ./
 
 # CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
+RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
          -Dspring.aot.enabled=true \
          -Dspring.profiles.active=cds \
          -Dspring.context.exit=onRefresh \
-         -jar stempo-api/build/libs/stempo-api.jar
+         org.springframework.boot.loader.JarLauncher
 
-# 2. 런타임 단계
-FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds
+
+# 4. 런타임 단계 \
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
 WORKDIR /app
 
-# JAR 파일 복사
-COPY --from=build /app/stempo-api/build/libs/stempo-api.jar ./stempo-api/build/libs/stempo-api.jar
+# 빌드 단계에서 생성된 레이어 복사
+COPY --from=cds /app/dependencies/ ./
+COPY --from=cds /app/spring-boot-loader/ ./
+COPY --from=cds /app/snapshot-dependencies/ ./
+COPY --from=cds /app/application/ ./
 
 # CDS 아카이브 파일 복사
-COPY --from=build /app/stempo-cds.jsa ./
+COPY --from=cds /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar ./stempo-api/build/libs/stempo-api.jar
 
 # CDS 아카이브 파일 복사
-COPY --from=build /app/stempo-cds.jsa ./
+#COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -18,31 +18,14 @@ COPY . /app
 # 애플리케이션 빌드
 RUN ./gradlew bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
 
-# 2. CDS 아카이브 생성 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-musl AS cds
-WORKDIR /app
-
-# 빌드된 JAR 파일 복사
-COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
-
-# CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
-         -Dspring.aot.enabled=true \
-         -Dspring.profiles.active=cds \
-         -Dspring.context.exit=onRefresh \
-         -jar stempo-api.jar
-
-# 3. 런타임 단계
+# 2. 런타임 단계
 FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
-# CDS 아카이브 파일 복사
-COPY --from=cds /app/stempo-cds.jsa ./
-
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]
+ENTRYPOINT ["java", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -18,14 +18,14 @@ RUN gradle dependencies --parallel --stacktrace
 
 # 소스 코드 복사 및 애플리케이션 빌드
 COPY . /app
-RUN gradle bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
+RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
 # CDS 아카이브 생성
-#RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
-#         -Dspring.aot.enabled=true \
-#         -Dspring.profiles.active=cds \
-#         -Dspring.context.exit=onRefresh \
-#         -jar stempo-api/build/libs/stempo-api.jar
+RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
+         -Dspring.aot.enabled=true \
+         -Dspring.profiles.active=cds \
+         -Dspring.context.exit=onRefresh \
+         -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
 FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds
@@ -35,9 +35,8 @@ WORKDIR /app
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar ./stempo-api/build/libs/stempo-api.jar
 
 # CDS 아카이브 파일 복사
-#COPY --from=build /app/stempo-cds.jsa ./
+COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-#ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
-ENTRYPOINT ["java", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "./stempo-api/build/libs/stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
 # Layered JAR 추출
-RUN java -Djarmode=layertools -jar /app/stempo-api.jar extract
+RUN java -Djarmode=tools -jar /app/stempo-api.jar extract --layers --launcher
 
 
 # 3. CDS 아카이브 생성 단계

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -47,7 +47,4 @@ COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java",
-            "-XX:SharedArchiveFile=stempo-cds.jsa",
-            "-Dspring.profiles.active=prod",
-            "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -16,9 +16,9 @@ RUN java -Djarmode=layertools -jar stempo-api/build/libs/stempo-api.jar extract
 
 # CDS 아카이브 생성
 RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
-    -Dspring.profiles.active=prod \
-    -Dspring.context.exit=onRefresh \
-    -jar stempo-api/build/libs/stempo-api.jar
+        -Dspring.profiles.active=cds \
+        -Dspring.context.exit=onRefresh \
+        -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
 FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS runtime

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -20,7 +20,7 @@ RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
     -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
-FROM bellsoft/liberica-runtime-container:jre-21-crac-cds-slim-musl AS runtime
+FROM bellsoft/liberica-runtime-container:jre-21-crac-cds-musl AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -18,30 +18,14 @@ COPY . /app
 # 애플리케이션 빌드
 RUN ./gradlew bootJar --no-daemon --build-cache --stacktrace
 
-# 2. CDS 아카이브 생성 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS cds
-WORKDIR /app
-
-# 빌드된 JAR 파일 복사
-COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
-
-# CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
-         -Dspring.profiles.active=cds \
-         -Dspring.context.exit=onRefresh \
-         -jar stempo-api.jar
-
-# 3. 런타임 단계
+# 2. 런타임 단계
 FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
-# CDS 아카이브 파일 복사
-COPY --from=cds /app/stempo-cds.jsa ./
-
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,5 +1,5 @@
 # 1. 빌드 단계
-FROM bellsoft/liberica-runtime-container:jdk-21-cds-slim-musl AS build
+FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5 AS build
 WORKDIR /app
 
 # Gradle Wrapper 복사 및 실행 권한 부여
@@ -16,16 +16,32 @@ RUN ./gradlew dependencies --parallel --stacktrace
 COPY . /app
 
 # 애플리케이션 빌드
-RUN ./gradlew bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
+RUN ./gradlew bootJar --no-daemon --build-cache --stacktrace
 
-# 2. 런타임 단계
+# 2. CDS 아카이브 생성 단계
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS cds
+WORKDIR /app
+
+# 빌드된 JAR 파일 복사
+COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
+
+# CDS 아카이브 생성
+RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
+         -Dspring.profiles.active=cds \
+         -Dspring.context.exit=onRefresh \
+         -jar stempo-api.jar
+
+# 3. 런타임 단계
 FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
+# CDS 아카이브 파일 복사
+COPY --from=cds /app/stempo-cds.jsa ./
+
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache curl unzip bash && \
     ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
-COPY build.gradle.kts settings.gradle /app/
+COPY build.gradle.kts settings.gradle.kts /app/
 COPY buildSrc /app/buildSrc
 RUN gradle dependencies --parallel --stacktrace
 
@@ -20,14 +20,17 @@ RUN gradle dependencies --parallel --stacktrace
 COPY . /app
 RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
+# JAR 파일 경로 확인 및 출력
+RUN echo "JAR 파일 위치:" && find /app -name "*.jar"
+
 # Layered JAR에서 레이어 추출
-RUN java -Djarmode=layertools -jar /app/stempo-api/build/libs/stempo-api.jar extract
+RUN java -Djarmode=layertools -jar $(find /app -name "stempo-api*.jar") extract
 
 # CDS 아카이브 생성
-RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
-        -Dspring.profiles.active=cds \
-        -Dspring.context.exit=onRefresh \
-        -jar stempo-api/build/libs/stempo-api.jar
+RUN java -XX:ArchiveClassesAtExit=/app/stempo-cds.jsa \
+         -Dspring.profiles.active=cds \
+         -Dspring.context.exit=onRefresh \
+         -jar $(find /app -name "stempo-api*.jar")
 
 # 2. 런타임 단계
 FROM bellsoft/liberica-openjdk-alpine-musl:21.0.5-cds AS runtime
@@ -44,4 +47,7 @@ COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java",
+            "-XX:SharedArchiveFile=stempo-cds.jsa",
+            "-Dspring.profiles.active=prod",
+            "org.springframework.boot.loader.launch.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -20,7 +20,7 @@ RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
     -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS runtime
+FROM bellsoft/liberica-runtime-container:jre-21-crac-cds-slim-musl AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -20,7 +20,7 @@ RUN ./gradlew bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stac
 
 
 # 2. Layered JAR 추출 단계
-FROM bellsoft/liberica-runtime-container:jdk-21-cds-slim-musl AS extract
+FROM bellsoft/liberica-runtime-container:jre-21-cds-musl AS extract
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
@@ -31,7 +31,7 @@ RUN java -Djarmode=layertools -jar /app/stempo-api.jar extract
 
 
 # 3. CDS 아카이브 생성 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS cds
+FROM bellsoft/liberica-runtime-container:jre-21-cds-musl AS cds
 WORKDIR /app
 
 # Layered JAR 복사

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -3,16 +3,16 @@ FROM gradle:8.11.1-jdk21 AS build
 WORKDIR /app
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
-COPY build.gradle.kts settings.gradle ./
-COPY buildSrc ./buildSrc
+COPY build.gradle.kts settings.gradle /app/
+COPY buildSrc /app/buildSrc
 RUN gradle dependencies --parallel --stacktrace
 
 # 소스 코드 복사 및 애플리케이션 빌드
-COPY . .
+COPY . /app
 RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
 # Layered JAR에서 레이어 추출
-RUN java -Djarmode=layertools -jar stempo-api/build/libs/stempo-api.jar extract
+RUN java -Djarmode=layertools -jar /app/stempo-api/build/libs/stempo-api.jar extract
 
 # CDS 아카이브 생성
 RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
@@ -25,13 +25,13 @@ FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사
-COPY --from=build dependencies/ ./
-COPY --from=build spring-boot-loader/ ./
-COPY --from=build snapshot-dependencies/ ./
-COPY --from=build application/ ./
+COPY --from=build /app/dependencies/ ./
+COPY --from=build /app/spring-boot-loader/ ./
+COPY --from=build /app/snapshot-dependencies/ ./
+COPY --from=build /app/application/ ./
 
 # CDS 아카이브 파일 복사
-COPY --from=build stempo-cds.jsa ./
+COPY --from=build /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -18,49 +18,31 @@ COPY . /app
 # 애플리케이션 빌드
 RUN ./gradlew bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
 
-
-# 2. Layered JAR 추출 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-musl AS extract
+# 2. CDS 아카이브 생성 단계
+FROM bellsoft/liberica-runtime-container:jre-21-cds-musl AS cds
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
-
-# Layered JAR 추출
-RUN java -Djarmode=layertools -jar /app/stempo-api.jar extract
-
-
-# 3. CDS 아카이브 생성 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-musl AS cds
-WORKDIR /app
-
-# Layered JAR 복사
-COPY --from=extract /app/dependencies/ ./
-COPY --from=extract /app/spring-boot-loader/ ./
-COPY --from=extract /app/snapshot-dependencies/ ./
-COPY --from=extract /app/application/ ./
 
 # CDS 아카이브 생성
 RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
          -Dspring.aot.enabled=true \
          -Dspring.profiles.active=cds \
          -Dspring.context.exit=onRefresh \
-         org.springframework.boot.loader.launch.JarLauncher
+         -jar stempo-api.jar
 
-
-# 4. 런타임 단계
+# 3. 런타임 단계
 FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
 WORKDIR /app
 
-# 빌드 단계에서 생성된 레이어 복사
-COPY --from=extract /app/dependencies/ ./
-COPY --from=extract /app/spring-boot-loader/ ./
-COPY --from=extract /app/snapshot-dependencies/ ./
-COPY --from=extract /app/application/ ./
+# 빌드된 JAR 파일 복사
+COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
 # CDS 아카이브 파일 복사
 COPY --from=cds /app/stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]
+
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -3,27 +3,35 @@ FROM gradle:8.11.1-jdk21 AS build
 WORKDIR /app
 
 # Gradle 설정 파일 및 buildSrc 복사 후 의존성 설치
-COPY build.gradle.kts settings.gradle /app/
-COPY buildSrc /app/buildSrc
+COPY build.gradle.kts settings.gradle ./
+COPY buildSrc ./buildSrc
 RUN gradle dependencies --parallel --stacktrace
 
 # 소스 코드 복사 및 애플리케이션 빌드
-COPY . /app
+COPY . .
 RUN gradle bootJar --no-daemon --build-cache --stacktrace
 
 # Layered JAR에서 레이어 추출
-RUN java -Djarmode=layertools -jar /app/stempo-api/build/libs/stempo-api.jar extract
+RUN java -Djarmode=tools -jar stempo-api/build/libs/stempo-api.jar extract
+
+# CDS 아카이브 생성
+RUN java -XX:ArchiveClassesAtExit=stempo-cds.jsa \
+    -Dspring.context.exit=onRefresh \
+    -jar stempo-api/build/libs/stempo-api.jar
 
 # 2. 런타임 단계
 FROM eclipse-temurin:21-jre AS runtime
 WORKDIR /app
 
 # 추출된 레이어 복사
-COPY --from=build /app/dependencies/ ./
-COPY --from=build /app/spring-boot-loader/ ./
-COPY --from=build /app/snapshot-dependencies/ ./
-COPY --from=build /app/application/ ./
+COPY --from=build dependencies/ ./
+COPY --from=build spring-boot-loader/ ./
+COPY --from=build snapshot-dependencies/ ./
+COPY --from=build application/ ./
+
+# CDS 아카이브 파일 복사
+COPY --from=build stempo-cds.jsa ./
 
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -16,16 +16,51 @@ RUN ./gradlew dependencies --parallel --stacktrace
 COPY . /app
 
 # 애플리케이션 빌드
-RUN ./gradlew bootJar --no-daemon --build-cache --stacktrace
+RUN ./gradlew bootJar -Pspring.aot.enabled=true --no-daemon --build-cache --stacktrace
 
-# 2. 런타임 단계
-FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
+
+# 2. Layered JAR 추출 단계
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS extract
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
+# Layered JAR 추출
+RUN java -Djarmode=layertools -jar /app/stempo-api.jar extract
+
+
+# 3. CDS 아카이브 생성 단계
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl AS cds
+WORKDIR /app
+
+# Layered JAR 복사
+COPY --from=extract /app/dependencies/ ./
+COPY --from=extract /app/spring-boot-loader/ ./
+COPY --from=extract /app/snapshot-dependencies/ ./
+COPY --from=extract /app/application/ ./
+
+# CDS 아카이브 생성
+RUN java -XX:ArchiveClassesAtExit=./stempo-cds.jsa \
+         -Dspring.aot.enabled=true \
+         -Dspring.profiles.active=cds \
+         -Dspring.context.exit=onRefresh \
+         org.springframework.boot.loader.launch.JarLauncher
+
+
+# 4. 런타임 단계
+FROM bellsoft/liberica-runtime-container:jre-21-cds-slim-musl
+WORKDIR /app
+
+# 빌드 단계에서 생성된 레이어 복사
+COPY --from=extract /app/dependencies/ ./
+COPY --from=extract /app/spring-boot-loader/ ./
+COPY --from=extract /app/snapshot-dependencies/ ./
+COPY --from=extract /app/application/ ./
+
+# CDS 아카이브 파일 복사
+COPY --from=cds /app/stempo-cds.jsa ./
+
 # 포트 설정 및 애플리케이션 실행
 EXPOSE 8080
-
-ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "stempo-api.jar"]
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=stempo-cds.jsa", "-Dspring.aot.enabled=true", "-Dspring.profiles.active=prod", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 COPY --from=build /app/stempo-api/build/libs/stempo-api.jar /app/stempo-api.jar
 
 # Layered JAR 추출
-RUN java -Djarmode=tools -jar /app/stempo-api.jar extract --layers --launcher
+RUN java -Djarmode=layertools -jar /app/stempo-api.jar extract
 
 
 # 3. CDS 아카이브 생성 단계

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'api'
-include ':stempo-common'
-include ':stempo-auth'
-include ':stempo-api'
-include ':stempo-application'
-include ':stempo-domain'
-include ':stempo-infrastructure'
+include(":stempo-common",
+        ":stempo-auth",
+        ":stempo-api",
+        ":stempo-application",
+        ":stempo-domain",
+        ":stempo-infrastructure")

--- a/stempo-api/build.gradle.kts
+++ b/stempo-api/build.gradle.kts
@@ -1,7 +1,10 @@
+import org.springframework.boot.gradle.tasks.aot.ProcessAot
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 tasks.named<BootJar>("bootJar") {
     enabled = true
+
+    dependsOn("processAot")
 
     layered {
         enabled = true
@@ -12,6 +15,11 @@ tasks.named<BootJar>("bootJar") {
     archiveFileName.set("${archiveBaseName.get()}.${archiveExtension.get()}")
 
     mainClass.set("com.stempo.ApiApplication")
+}
+
+tasks.named<ProcessAot>("processAot") {
+    enabled = true
+    dependsOn("classes")
 }
 
 dependencies {

--- a/stempo-api/src/main/java/com/stempo/interceptor/ApiLoggingInterceptor.java
+++ b/stempo-api/src/main/java/com/stempo/interceptor/ApiLoggingInterceptor.java
@@ -3,7 +3,6 @@ package com.stempo.interceptor;
 import com.stempo.util.ApiLogger;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -13,15 +12,14 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class ApiLoggingInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response,
-            @NotNull Object handler) {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         request.setAttribute("startTime", System.currentTimeMillis());
         return true;
     }
 
     @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, @NotNull Object handler,
-            Exception ex) {
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+                                Exception ex) {
         ApiLogger.logRequestDuration(request, response, ex);
     }
 }

--- a/stempo-infrastructure/build.gradle.kts
+++ b/stempo-infrastructure/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 
     // DB
     implementation(Dependencies.mariadbDriver)
-    testRuntimeOnly(Dependencies.h2database)
+    implementation(Dependencies.h2database)
 
     // Util
     implementation(Dependencies.jakartaValidationApi)


### PR DESCRIPTION
## Summary

> #90 

Spring Boot 애플리케이션의 성능 최적화를 위해 CDS와 AOT를 Docker 빌드 프로세스에 통합하여 애플리케이션의 시작 시간을 단축하고 메모리 사용량을 줄였습니다.

## Tasks

- 빌드 단계에서 CDS 아카이브 생성
- 빌드 단계에서 생성된 `.jsa` 파일을 런타임 단계로 복사
- 런타임에서 CDS 적용
- AOT 플러그인 추가

## ETC

- 기존 Dockerfile을 수정하여 최적화 기법을 통합하였습니다.
- 테스트 환경에서 최적화된 Docker 이미지의 성능을 검증하였으며, 성능 향상을 확인하였습니다.

## 성능 비교

**기존 설정**: Docker Multi-stage Builds + Layered JAR
**최적화**: CDS + AOT

### 애플리케이션 시작 시간

| 조건                  | 시작 시간 (초) | 개선율 (%) |
|-----------------------|---------------|------------|
| 기존 설정             | 20.024        | 0.00%      |
| 최적화             | 15.241        | 23.89%     |

### 메모리 사용량

| 조건                  | 메모리 사용량 (MB) | 개선율 (%) |
|-----------------------|-------------------|------------|
| 기본 설정             | 350.7             | 0.00%      |
| 최적화             | 294.3             | 16.09%     |

### 이미지 크기

| 조건          | 이미지 크기 (MB) | 개선율 (%) |
|---------------|------------------|------------|
| 기존 설정     | 149.85           | 0.00%      |
| 최적화     | 133.34           | 11.02%     |