### PR TITLE
fix: 로그인 및 TOTP 인증 상태코드 수정 및 API 문서 비밀번호 정책 설명 추가 완료

### DIFF
--- a/stempo-api/src/main/java/com/stempo/controller/AuthController.java
+++ b/stempo-api/src/main/java/com/stempo/controller/AuthController.java
@@ -25,7 +25,12 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "회원 가입", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @Operation(summary = "회원 가입", description = "ROLE_ANONYMOUS 이상의 권한이 필요함<br>"
+        + "<br><b>[비밀번호 정책]</b><br>"
+        + "최소 8자리 이상, 최대 16자리 이하<br>"
+        + "영문 대문자, 소문자, 숫자, 특수문자 중 최소 3가지가 포함<br>"
+        + "연속된 문자나 숫자 3개 이상 금지"
+        + "비밀번호에 사용자 아이디의 4자 이상 연속된 부분 문자열 포함 금지")
     @PostMapping("/api/v1/auth/register")
     public ApiResponse<TokenInfo> registerUser(
         @Valid @RequestBody AuthRequestDto requestDto

--- a/stempo-application/src/main/java/com/stempo/service/AuthServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/AuthServiceImpl.java
@@ -4,11 +4,9 @@ import com.stempo.application.JwtTokenService;
 import com.stempo.dto.TokenInfo;
 import com.stempo.dto.request.AuthRequestDto;
 import com.stempo.dto.request.TwoFactorAuthenticationRequestDto;
-import com.stempo.exception.BaseException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +36,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    @Transactional(noRollbackFor = {BadCredentialsException.class, BaseException.class})
+    @Transactional
     public Object login(AuthRequestDto requestDto) {
         return new LoginCommand(authenticationService, requestDto, jwtTokenService, totpAuthenticatorService).execute();
     }
@@ -50,7 +48,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    @Transactional(noRollbackFor = {BadCredentialsException.class})
+    @Transactional
     public TokenInfo authenticate(TwoFactorAuthenticationRequestDto requestDto) {
         return totpService.authenticate(requestDto, jwtTokenService);
     }

--- a/stempo-application/src/main/java/com/stempo/service/AuthenticationService.java
+++ b/stempo-application/src/main/java/com/stempo/service/AuthenticationService.java
@@ -4,9 +4,10 @@ import com.stempo.application.JwtTokenService;
 import com.stempo.config.AesConfig;
 import com.stempo.config.CustomAuthenticationProvider;
 import com.stempo.dto.request.AuthRequestDto;
+import com.stempo.exception.BaseException;
+import com.stempo.exception.ErrorCode;
 import com.stempo.util.EncryptionUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class AuthenticationService {
             return handleTwoFactorIfRequired(deviceTag, authentication, authenticatorService, tokenService);
         } catch (Exception e) {
             userService.handleFailedLogin(deviceTag);
-            throw new BadCredentialsException("Invalid deviceTag or password.");
+            throw new BaseException(ErrorCode.BAD_CREDENTIALS, "Invalid deviceTag or password.");
         }
     }
 

--- a/stempo-application/src/main/java/com/stempo/service/TotpService.java
+++ b/stempo-application/src/main/java/com/stempo/service/TotpService.java
@@ -4,10 +4,11 @@ import com.stempo.application.JwtTokenService;
 import com.stempo.config.AesConfig;
 import com.stempo.dto.TokenInfo;
 import com.stempo.dto.request.TwoFactorAuthenticationRequestDto;
+import com.stempo.exception.BaseException;
+import com.stempo.exception.ErrorCode;
 import com.stempo.model.Role;
 import com.stempo.util.EncryptionUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,7 +40,7 @@ public class TotpService {
         userService.handleAccountLock(deviceTag);
         if (!authenticatorService.isAuthenticatorValid(deviceTag, totp)) {
             userService.handleFailedLogin(deviceTag);
-            throw new BadCredentialsException("잘못된 TOTP 코드입니다.");
+            throw new BaseException(ErrorCode.BAD_CREDENTIALS, "잘못된 TOTP 코드입니다.");
         }
     }
 

--- a/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/UserServiceImpl.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,6 +89,7 @@ public class UserServiceImpl implements UserService {
 
     private User getUserById(String deviceTag) {
         return findById(deviceTag)
-                .orElseThrow(() -> new BadCredentialsException("[User] id: " + deviceTag + " not found"));
+            .orElseThrow(() -> new BaseException(ErrorCode.BAD_CREDENTIALS,
+                "[User] id: " + deviceTag + " not found"));
     }
 }

--- a/stempo-application/src/test/java/com/stempo/service/AuthenticationServiceTest.java
+++ b/stempo-application/src/test/java/com/stempo/service/AuthenticationServiceTest.java
@@ -14,6 +14,7 @@ import com.stempo.config.AesConfig;
 import com.stempo.config.CustomAuthenticationProvider;
 import com.stempo.dto.TokenInfo;
 import com.stempo.dto.request.AuthRequestDto;
+import com.stempo.exception.BaseException;
 import com.stempo.model.Role;
 import com.stempo.model.User;
 import com.stempo.util.EncryptionUtils;
@@ -78,7 +79,7 @@ class AuthenticationServiceTest {
         when(encryptionUtils.encryptWithHashedIv(anyString(), anyString())).thenReturn(encryptedDeviceTag);
         when(userService.getById(encryptedDeviceTag)).thenReturn(user);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenReturn(authentication);
+            .thenReturn(authentication);
         when(authenticatorService.isAuthenticatorExist(encryptedDeviceTag)).thenReturn(false);
         when(tokenService.generateToken(authentication)).thenReturn(tokenInfo);
 
@@ -98,12 +99,12 @@ class AuthenticationServiceTest {
 
         when(encryptionUtils.encryptWithHashedIv(eq(deviceTag), anyString())).thenReturn(encryptedDeviceTag);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenThrow(new BadCredentialsException("Invalid deviceTag or password."));
+            .thenThrow(new BadCredentialsException("Invalid deviceTag or password."));
 
         // when, then
         assertThatThrownBy(() -> authenticationService.login(authRequestDto, tokenService, authenticatorService))
-                .isInstanceOf(BadCredentialsException.class)
-                .hasMessage("Invalid deviceTag or password.");
+            .isInstanceOf(BaseException.class)
+            .hasMessage("Invalid deviceTag or password.");
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(userService).handleFailedLogin(captor.capture());
@@ -114,16 +115,14 @@ class AuthenticationServiceTest {
     void 관리자_로그인에_성공하고_TOTP가_존재하면_null을_반환한다() {
         // given
         String deviceTag = "admin-device";
-        String encryptedDeviceTag = "encrypted-admin-device";
         User adminUser = User.builder().deviceTag(deviceTag).role(Role.ADMIN).build();
 
         when(encryptionUtils.encryptWithHashedIv(anyString(), anyString())).thenReturn(encryptedDeviceTag);
         when(userService.getById(encryptedDeviceTag)).thenReturn(adminUser);
         when(authenticatorService.isAuthenticatorExist(encryptedDeviceTag)).thenReturn(true);
 
-        Authentication authentication = mock(Authentication.class);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenReturn(authentication);
+            .thenReturn(authentication);
 
         // when
         Object result = authenticationService.login(authRequestDto, tokenService, authenticatorService);
@@ -137,7 +136,6 @@ class AuthenticationServiceTest {
     void 관리자_로그인에_성공하고_TOTP가_존재하지_않으면_비밀키를_반환한다() {
         // given
         String deviceTag = "admin-device";
-        String encryptedDeviceTag = "encrypted-admin-device";
         User adminUser = User.builder().deviceTag(deviceTag).role(Role.ADMIN).build();
 
         when(encryptionUtils.encryptWithHashedIv(anyString(), anyString())).thenReturn(encryptedDeviceTag);
@@ -145,9 +143,8 @@ class AuthenticationServiceTest {
         when(authenticatorService.isAuthenticatorExist(encryptedDeviceTag)).thenReturn(false);
         when(authenticatorService.generateSecretKey(encryptedDeviceTag)).thenReturn("secret-key");
 
-        Authentication authentication = mock(Authentication.class);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenReturn(authentication);
+            .thenReturn(authentication);
 
         // when
         Object result = authenticationService.login(authRequestDto, tokenService, authenticatorService);

--- a/stempo-application/src/test/java/com/stempo/service/TotpServiceTest.java
+++ b/stempo-application/src/test/java/com/stempo/service/TotpServiceTest.java
@@ -12,6 +12,7 @@ import com.stempo.application.JwtTokenService;
 import com.stempo.config.AesConfig;
 import com.stempo.dto.TokenInfo;
 import com.stempo.dto.request.TwoFactorAuthenticationRequestDto;
+import com.stempo.exception.BaseException;
 import com.stempo.model.Role;
 import com.stempo.model.User;
 import com.stempo.util.EncryptionUtils;
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.BadCredentialsException;
 
 @ExtendWith(MockitoExtension.class)
 class TotpServiceTest {
@@ -88,8 +88,8 @@ class TotpServiceTest {
 
         // when, then
         assertThatThrownBy(() -> totpService.authenticate(requestDto, tokenService))
-                .isInstanceOf(BadCredentialsException.class)
-                .hasMessage("잘못된 TOTP 코드입니다.");
+            .isInstanceOf(BaseException.class)
+            .hasMessage("잘못된 TOTP 코드입니다.");
 
         verify(userService).handleAccountLock(encryptedDeviceTag);
         verify(authenticatorService).isAuthenticatorValid(encryptedDeviceTag, requestDto.getTotp());

--- a/stempo-application/src/test/java/com/stempo/service/UserServiceImplTest.java
+++ b/stempo-application/src/test/java/com/stempo/service/UserServiceImplTest.java
@@ -20,7 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.BadCredentialsException;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -80,12 +79,12 @@ class UserServiceImplTest {
     void 존재하지_않는_아이디로_사용자를_조회하면_예외를_던진다() {
         // given
         when(repository.findByIdOrThrow("non-existent-device-tag"))
-                .thenThrow(new BaseException(ErrorCode.RESOURCE_NOT_FOUND));
+            .thenThrow(new BaseException(ErrorCode.RESOURCE_NOT_FOUND));
 
         // when, then
         assertThatThrownBy(() -> userService.getById("non-existent-device-tag"))
-                .isInstanceOf(BaseException.class)
-                .hasMessage(ErrorCode.RESOURCE_NOT_FOUND.getDefaultMessage());
+            .isInstanceOf(BaseException.class)
+            .hasMessage(ErrorCode.RESOURCE_NOT_FOUND.getDefaultMessage());
         verify(repository).findByIdOrThrow("non-existent-device-tag");
     }
 
@@ -151,8 +150,8 @@ class UserServiceImplTest {
 
         // when, then
         assertThatThrownBy(() -> userService.handleAccountLock("test-device-tag"))
-                .isInstanceOf(BaseException.class)
-                .hasMessage(ErrorCode.ACCOUNT_LOCKED.getDefaultMessage());
+            .isInstanceOf(BaseException.class)
+            .hasMessage(ErrorCode.ACCOUNT_LOCKED.getDefaultMessage());
         verify(repository).findById("test-device-tag");
     }
 
@@ -194,8 +193,8 @@ class UserServiceImplTest {
 
         // when, then
         assertThatThrownBy(() -> userService.handleAccountLock("non-existent-device-tag"))
-                .isInstanceOf(BadCredentialsException.class)
-                .hasMessage("[User] id: non-existent-device-tag not found");
+            .isInstanceOf(BaseException.class)
+            .hasMessage("[User] id: non-existent-device-tag not found");
         verify(repository).findById("non-existent-device-tag");
     }
 }


### PR DESCRIPTION
## Summary

> #98 

로그인 API와 TOTP 인증 API의 상태코드 반환 문제를 수정하고, 회원 가입 API 문서에 비밀번호 정책 설명을 추가하였습니다. 이를 통해 클라이언트 개발자의 편의성을 높이고, 상태코드 반환의 일관성을 확보하였습니다.

## Tasks

- **로그인 API 수정**: 존재하지 않는 ID 입력 시 상태코드를 `401 BAD_CREDENTIALS`로 반환하도록 수정.
- **TOTP 인증 API 수정**: 잘못된 TOTP 코드 입력 시 상태코드를 `401 BAD_CREDENTIALS`로 반환하도록 수정.
- **회원 가입 API 문서 업데이트**: 다음 비밀번호 정책을 문서에 추가:
  - 최소 8자리 이상, 최대 16자리 이하
  - 영문 대문자, 소문자, 숫자, 특수문자 중 최소 3가지 포함
  - 연속된 문자나 숫자 3개 이상 금지
  - 비밀번호에 사용자 아이디의 4자 이상 연속된 부분 문자열 포함 금지

## ETC

- 비밀번호 정책은 **KISA 패스워드 선택 및 이용 안내서**를 참고하여 작성하였습니다.
- 수정 후 단위 테스트와 통합 테스트를 통해 정상 동작을 확인하였습니다.