### PR TITLE
fix: 과제 조회 API에서 사용자별 데이터 필터링 수정 완료

### DIFF
--- a/stempo-application/src/main/java/com/stempo/service/HomeworkServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/HomeworkServiceImpl.java
@@ -39,7 +39,8 @@ public class HomeworkServiceImpl implements HomeworkService {
     @Override
     @Transactional(readOnly = true)
     public PagedResponseDto<HomeworkResponseDto> getHomeworks(Boolean completed, Pageable pageable) {
-        Page<Homework> homeworksPage = repository.findByCompleted(completed, pageable);
+        String deviceTag = userService.getCurrentDeviceTag();
+        Page<Homework> homeworksPage = repository.findByDeviceTagAndCompleted(deviceTag, completed, pageable);
 
         List<HomeworkResponseDto> responseDtos = homeworksPage.getContent().stream()
             .map(this::decryptAndConvertToDto)

--- a/stempo-application/src/test/java/com/stempo/service/HomeworkServiceImplTest.java
+++ b/stempo-application/src/test/java/com/stempo/service/HomeworkServiceImplTest.java
@@ -102,10 +102,12 @@ class HomeworkServiceImplTest {
         Boolean completed = false;
         Sort sort = Sort.by("description").ascending();
         Pageable pageable = PageRequest.of(0, 10, sort);
+        String deviceTag = "someDeviceTag"; // 추가
 
-        // Homework 객체 생성 (null이 아니도록)
+        // Homework 객체 생성
         Homework homework = Homework.builder()
             .id(1L)
+            .deviceTag(deviceTag) // 추가
             .description("Encrypted Description")
             .completed(false)
             .build();
@@ -119,14 +121,16 @@ class HomeworkServiceImplTest {
 
         DecryptedHomework decryptedHomework = DecryptedHomework.builder()
             .id(homework.getId())
-            .deviceTag("someDeviceTag")
+            .deviceTag(deviceTag)
             .description("Decrypted Description")
             .completed(homework.getCompleted())
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())
             .build();
 
-        when(repository.findByCompleted(completed, pageable))
+        when(userService.getCurrentDeviceTag()).thenReturn(deviceTag);
+
+        when(repository.findByDeviceTagAndCompleted(deviceTag, completed, pageable))
             .thenReturn(new PageImpl<>(homeworkList, pageable, homeworkList.size()));
         when(homeworkDecryptionService.decryptHomework(any(Homework.class))).thenReturn(decryptedHomework);
         doReturn(responseDto).when(mapper).toDto(decryptedHomework);
@@ -145,11 +149,13 @@ class HomeworkServiceImplTest {
             // then
             assertThat(result.getItems()).hasSize(1);
             assertThat(result.getItems().getFirst().getDescription()).isEqualTo("Decrypted Description");
-            verify(repository).findByCompleted(completed, pageable);
+            verify(userService).getCurrentDeviceTag();
+            verify(repository).findByDeviceTagAndCompleted(deviceTag, completed, pageable);
             verify(homeworkDecryptionService).decryptHomework(any(Homework.class));
             verify(mapper).toDto(decryptedHomework);
         }
     }
+
 
     @Test
     void 과제를_수정한다() {

--- a/stempo-domain/src/main/java/com/stempo/repository/HomeworkRepository.java
+++ b/stempo-domain/src/main/java/com/stempo/repository/HomeworkRepository.java
@@ -13,7 +13,7 @@ public interface HomeworkRepository {
 
     void deleteAll(List<Homework> homeworks);
 
-    Page<Homework> findByCompleted(Boolean completed, Pageable pageable);
+    Page<Homework> findByDeviceTagAndCompleted(String deviceTag, Boolean completed, Pageable pageable);
 
     Homework findByIdOrThrow(Long homeworkId);
 

--- a/stempo-infrastructure/src/main/java/com/stempo/repository/HomeworkJpaRepository.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/repository/HomeworkJpaRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HomeworkJpaRepository extends JpaRepository<HomeworkEntity, Long>, HomeworkCustomRepository {
 
-    Page<HomeworkEntity> findByCompleted(Boolean completed, Pageable pageable);
+    Page<HomeworkEntity> findByDeviceTagAndCompleted(String deviceTag, Boolean completed, Pageable pageable);
+
+    Page<HomeworkEntity> findByDeviceTag(String deviceTag, Pageable pageable);
 
     List<HomeworkEntity> findByDeviceTag(String deviceTag);
 }

--- a/stempo-infrastructure/src/main/java/com/stempo/repository/HomeworkRepositoryImpl.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/repository/HomeworkRepositoryImpl.java
@@ -41,11 +41,12 @@ public class HomeworkRepositoryImpl implements HomeworkRepository {
     }
 
     @Override
-    public Page<Homework> findByCompleted(Boolean completed, Pageable pageable) {
-        return Optional.ofNullable(completed)
-            .map(c -> repository.findByCompleted(c, pageable))
-            .orElseGet(() -> repository.findAll(pageable))
-            .map(mapper::toDomain);
+    public Page<Homework> findByDeviceTagAndCompleted(String deviceTag, Boolean completed, Pageable pageable) {
+        Page<HomeworkEntity> page = Optional.ofNullable(completed)
+            .map(c -> repository.findByDeviceTagAndCompleted(deviceTag, c, pageable))
+            .orElseGet(() -> repository.findByDeviceTag(deviceTag, pageable));
+
+        return page.map(mapper::toDomain);
     }
 
 

--- a/stempo-infrastructure/src/main/java/com/stempo/repository/HomeworkRepositoryImpl.java
+++ b/stempo-infrastructure/src/main/java/com/stempo/repository/HomeworkRepositoryImpl.java
@@ -49,7 +49,6 @@ public class HomeworkRepositoryImpl implements HomeworkRepository {
         return page.map(mapper::toDomain);
     }
 
-
     @Override
     public Homework findByIdOrThrow(Long homeworkId) {
         return repository.findById(homeworkId)

--- a/stempo-infrastructure/src/test/java/com/stempo/repository/HomeworkRepositoryImplTest.java
+++ b/stempo-infrastructure/src/test/java/com/stempo/repository/HomeworkRepositoryImplTest.java
@@ -3,7 +3,6 @@ package com.stempo.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -104,17 +103,34 @@ class HomeworkRepositoryImplTest {
         // given
         Pageable pageable = mock(Pageable.class);
         Page<HomeworkEntity> homeworkEntityPage = new PageImpl<>(List.of(homeworkEntity));
-        when(homeworkJpaRepository.findByDeviceTagAndCompleted(anyString(), anyBoolean(), any(Pageable.class))).thenReturn(
-            homeworkEntityPage);
-        when(homeworkMapper.toDomain(any(HomeworkEntity.class))).thenReturn(homework);
+        when(homeworkJpaRepository.findByDeviceTagAndCompleted("deviceTag", true, pageable))
+            .thenReturn(homeworkEntityPage);
+        when(homeworkMapper.toDomain(homeworkEntity)).thenReturn(homework);
 
         // when
         Page<Homework> homeworkPage = homeworkRepository.findByDeviceTagAndCompleted("deviceTag", true, pageable);
 
         // then
         assertThat(homeworkPage.getContent()).hasSize(1);
-        assertThat(homeworkPage.getContent().getFirst()).isEqualTo(homework);
+        assertThat(homeworkPage.getContent().get(0)).isEqualTo(homework);
         verify(homeworkJpaRepository, times(1)).findByDeviceTagAndCompleted("deviceTag", true, pageable);
+    }
+
+    @Test
+    void 완료여부가_null인_경우_디바이스_태그로_페이지_조회한다() {
+        // given
+        Pageable pageable = mock(Pageable.class);
+        Page<HomeworkEntity> homeworkEntityPage = new PageImpl<>(List.of(homeworkEntity));
+        when(homeworkJpaRepository.findByDeviceTag("deviceTag", pageable)).thenReturn(homeworkEntityPage);
+        when(homeworkMapper.toDomain(homeworkEntity)).thenReturn(homework);
+
+        // when
+        Page<Homework> homeworkPage = homeworkRepository.findByDeviceTagAndCompleted("deviceTag", null, pageable);
+
+        // then
+        assertThat(homeworkPage.getContent()).hasSize(1);
+        assertThat(homeworkPage.getContent().getFirst()).isEqualTo(homework);
+        verify(homeworkJpaRepository, times(1)).findByDeviceTag("deviceTag", pageable);
     }
 
     @Test

--- a/stempo-infrastructure/src/test/java/com/stempo/repository/HomeworkRepositoryImplTest.java
+++ b/stempo-infrastructure/src/test/java/com/stempo/repository/HomeworkRepositoryImplTest.java
@@ -104,16 +104,17 @@ class HomeworkRepositoryImplTest {
         // given
         Pageable pageable = mock(Pageable.class);
         Page<HomeworkEntity> homeworkEntityPage = new PageImpl<>(List.of(homeworkEntity));
-        when(homeworkJpaRepository.findByCompleted(anyBoolean(), any(Pageable.class))).thenReturn(homeworkEntityPage);
+        when(homeworkJpaRepository.findByDeviceTagAndCompleted(anyString(), anyBoolean(), any(Pageable.class))).thenReturn(
+            homeworkEntityPage);
         when(homeworkMapper.toDomain(any(HomeworkEntity.class))).thenReturn(homework);
 
         // when
-        Page<Homework> homeworkPage = homeworkRepository.findByCompleted(true, pageable);
+        Page<Homework> homeworkPage = homeworkRepository.findByDeviceTagAndCompleted("deviceTag", true, pageable);
 
         // then
         assertThat(homeworkPage.getContent()).hasSize(1);
         assertThat(homeworkPage.getContent().getFirst()).isEqualTo(homework);
-        verify(homeworkJpaRepository, times(1)).findByCompleted(true, pageable);
+        verify(homeworkJpaRepository, times(1)).findByDeviceTagAndCompleted("deviceTag", true, pageable);
     }
 
     @Test


### PR DESCRIPTION
## Summary

> #108 

과제 조회 API에서 현재 사용자(`deviceTag`)의 과제만 반환하도록 수정하고, 이에 맞춰 테스트 코드도 수정하였습니다.
기존에는 전체 사용자의 과제가 반환되는 문제가 있었으나, 이를 사용자별 필터링이 적용되도록 수정하였습니다.

## Tasks

- 과제 조회 API 수정
  - 현재 API에서 전체 사용자의 과제 데이터를 반환하는 문제 수정
  - 요청한 사용자의 `device_tag`를 기준으로 해당 사용자의 과제만 필터링하여 반환하도록 변경