### PR TITLE
fix: 최대 연속 훈련 일수 계산 연속성 체크 문제 수정 완료

### DIFF
--- a/stempo-application/src/main/java/com/stempo/service/RecordServiceImpl.java
+++ b/stempo-application/src/main/java/com/stempo/service/RecordServiceImpl.java
@@ -101,7 +101,7 @@ public class RecordServiceImpl implements RecordService {
             deviceTag, weekStartDateTime, todayEndDateTime);
 
         // 연속된 훈련 일수 계산
-        int consecutiveWalkTrainingDays = calculateConsecutiveTrainingDays(deviceTag);
+        int consecutiveWalkTrainingDays = calculateMaxConsecutiveTrainingDays(deviceTag);
 
         return mapper.toDto(todayWalkTrainingCount, weeklyWalkTrainingCount, consecutiveWalkTrainingDays);
     }
@@ -131,23 +131,29 @@ public class RecordServiceImpl implements RecordService {
             .toList();
     }
 
-    private int calculateConsecutiveTrainingDays(String deviceTag) {
-        List<LocalDateTime> createdDates = recordRepository.findCreatedAtByDeviceTagOrderByCreatedAtDesc(deviceTag);
-        int consecutiveDays = 0;
-        LocalDate previousDate = null;
+    private int calculateMaxConsecutiveTrainingDays(String deviceTag) {
+        List<LocalDate> uniqueDates = recordRepository.findCreatedAtByDeviceTagOrderByCreatedAtDesc(deviceTag)
+            .stream()
+            .map(LocalDateTime::toLocalDate)
+            .distinct()
+            .toList();
 
-        for (LocalDateTime createdAt : createdDates) {
-            LocalDate recordDate = createdAt.toLocalDate();
+        if (uniqueDates.isEmpty()) {
+            return 0;
+        }
 
-            // 첫 기록이거나, 이전 기록이 하루 전날이면 연속으로 카운트
-            if (previousDate == null || previousDate.minusDays(1).isEqual(recordDate)) {
-                consecutiveDays++;
-                previousDate = recordDate;
+        int maxStreak = 1;
+        int currentStreak = 1;
+
+        for (int i = 1; i < uniqueDates.size(); i++) {
+            // 이전 날짜의 하루 전이 현재 날짜이면 연속
+            if (uniqueDates.get(i - 1).minusDays(1).equals(uniqueDates.get(i))) {
+                currentStreak++;
             } else {
-                // 연속된 날짜가 아니면 중단
-                break;
+                maxStreak = Math.max(maxStreak, currentStreak);
+                currentStreak = 1;
             }
         }
-        return consecutiveDays;
+        return Math.max(maxStreak, currentStreak);
     }
 }


### PR DESCRIPTION
## Summary

> #110 

기존 `calculateConsecutiveTrainingDays` 메서드는 가장 최근 기록부터 연속된 날짜만 계산하고, 비연속적인 시점에서 즉시 중단하는 방식으로 동작하여 전체 기록에서 최대 연속 훈련 일수를 정확하게 계산하지 못하는 문제가 있었습니다. 이를 해결하기 위해 전체 고유 날짜 목록을 대상으로 연속 훈련 일수를 탐색하여 최대 연속 일수를 계산하는 방식으로 개선하였습니다.

## Tasks

-  **연속 훈련 일수 계산 로직 수정**
  - 기존: 가장 최근 기록부터 연속된 날짜만 확인하여 비연속 시점에서 즉시 중단
  - 변경: 전체 고유 날짜 목록을 대상으로 연속 구간을 탐색하여 최대 연속 훈련 일수를 계산